### PR TITLE
Add stats API

### DIFF
--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -13,9 +13,12 @@ require "jsonapi_compliable/scope/extra_fields"
 require "jsonapi_compliable/scope/filterable"
 require "jsonapi_compliable/scope/default_filter"
 require "jsonapi_compliable/scope/filter"
+require "jsonapi_compliable/stats/dsl"
+require "jsonapi_compliable/stats/payload"
 require "jsonapi_compliable/util/include_params"
 require "jsonapi_compliable/util/field_params"
 require "jsonapi_compliable/util/scoping"
+require "jsonapi_compliable/util/pagination"
 
 require 'jsonapi_compliable/railtie' if defined?(::Rails)
 

--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -11,5 +11,26 @@ module JsonapiCompliable
         "Requested page size #{@size} is greater than max supported size #{@max}"
       end
     end
+
+    class StatNotFound < StandardError
+      def initialize(attribute, calculation)
+        @attribute = attribute
+        @calculation = calculation
+      end
+
+      def message
+        "No stat configured for calculation #{pretty(@calculation)} on attribute #{pretty(@attribute)}"
+      end
+
+      private
+
+      def pretty(input)
+        if input.is_a?(Symbol)
+          ":#{input}"
+        else
+          "'#{input}'"
+        end
+      end
+    end
   end
 end

--- a/lib/jsonapi_compliable/stats/dsl.rb
+++ b/lib/jsonapi_compliable/stats/dsl.rb
@@ -1,0 +1,54 @@
+module JsonapiCompliable
+  module Stats
+    class DSL
+      attr_reader :name, :calculations
+
+      def self.defaults
+        {
+          count: ->(scope, attr) { scope.count },
+          average: ->(scope, attr) { scope.average(attr).to_f },
+          sum: ->(scope, attr) { scope.sum(attr) },
+          maximum: ->(scope, attr) { scope.maximum(attr) },
+          minimum: ->(scope, attr) { scope.minimum(attr) }
+        }
+      end
+
+      def initialize(config)
+        config = { config => [] } if config.is_a?(Symbol)
+
+        @calculations = {}
+        @name = config.keys.first
+        Array(config.values.first).each { |c| send(:"#{c}!") }
+      end
+
+      def method_missing(meth, *args, &blk)
+        @calculations[meth] = blk
+      end
+
+      def calculation(name)
+        callable = @calculations[name] || @calculations[name.to_sym]
+        callable || raise(Errors::StatNotFound.new(@name, name))
+      end
+
+      def count!
+        @calculations[:count] = self.class.defaults[:count]
+      end
+
+      def sum!
+        @calculations[:sum] = self.class.defaults[:sum]
+      end
+
+      def average!
+        @calculations[:average] = self.class.defaults[:average]
+      end
+
+      def maximum!
+        @calculations[:maximum] = self.class.defaults[:maximum]
+      end
+
+      def minimum!
+        @calculations[:minimum] = self.class.defaults[:minimum]
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/stats/payload.rb
+++ b/lib/jsonapi_compliable/stats/payload.rb
@@ -1,0 +1,34 @@
+module JsonapiCompliable
+  module Stats
+    class Payload
+      def initialize(controller, scope)
+        @dsl       = controller._jsonapi_compliable
+        @directive = controller.params[:stats]
+        @scope     = controller._jsonapi_scope || scope
+      end
+
+      def generate
+        {}.tap do |stats|
+          @directive.each_pair do |name, calculation|
+            stats[name] = {}
+
+            each_calculation(name, calculation) do |calc, function|
+              stats[name][calc] = function.call(@scope, name)
+            end
+          end
+        end
+      end
+
+      private
+
+      def each_calculation(name, calculation_string)
+        calculations = calculation_string.split(',').map(&:to_sym)
+
+        calculations.each do |calc|
+          function = @dsl.stat(name, calc)
+          yield calc, function
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/util/pagination.rb
+++ b/lib/jsonapi_compliable/util/pagination.rb
@@ -1,0 +1,11 @@
+module JsonapiCompliable
+  module Util
+    class Pagination
+      def self.zero?(params)
+        params = params[:page] || params['page'] || {}
+        size   = params[:size] || params['size']
+        [0, '0'].include?(size)
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/util/scoping.rb
+++ b/lib/jsonapi_compliable/util/scoping.rb
@@ -3,9 +3,9 @@ module JsonapiCompliable
     class Scoping
       def self.apply?(controller, object, force)
         return false if force == false
-        return true if !controller._jsonapi_scoped && object.is_a?(ActiveRecord::Relation)
+        return true if controller._jsonapi_scope.nil? && object.is_a?(ActiveRecord::Relation)
 
-        already_scoped = !!controller._jsonapi_scoped
+        already_scoped = !!controller._jsonapi_scope
         is_activerecord = object.is_a?(ActiveRecord::Base)
         is_activerecord_array = object.is_a?(Array) && object[0].is_a?(ActiveRecord::Base)
 

--- a/spec/jsonapi_compliable_spec.rb
+++ b/spec/jsonapi_compliable_spec.rb
@@ -85,10 +85,11 @@ RSpec.describe JsonapiCompliable, type: :controller do
     end
 
     it 'resets scope flag after action' do
+      controller.instance_variable_set(:@_jsonapi_scope, 'a')
       expect {
         get :index
-      }.to change { controller.instance_variable_get(:@_jsonapi_scoped) }
-        .from(nil).to(false)
+      }.to change { controller.instance_variable_get(:@_jsonapi_scope) }
+        .from('a').to(nil)
     end
 
     context 'when passing scope: false' do

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe 'pagination', type: :controller do
     expect(json_ids(true)).to eq([author3.id, author4.id])
   end
 
+  # for metadata
+  context 'with page size 0' do
+    it 'should not respond with records, but still respond' do
+      get :index, params: { page: { size: 0 } }
+      expect(json_ids).to eq([])
+    end
+  end
+
   context 'and a custom pagination function is given' do
     before do
       controller.class_eval do

--- a/spec/stats/dsl_spec.rb
+++ b/spec/stats/dsl_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe JsonapiCompliable::Stats::DSL do
+  let(:config) { :myattr }
+  let(:instance) { described_class.new(config) }
+
+  describe '.new' do
+    it 'sets name' do
+      expect(instance.name).to eq(:myattr)
+    end
+
+    it 'sets calculations' do
+      expect(instance.calculations).to eq({})
+    end
+
+    context 'when passed a hash' do
+      it 'applies defaults' do
+        expect_any_instance_of(described_class)
+          .to receive(:count!).and_call_original
+        instance = described_class.new(myattr: [:count])
+        expect(instance.calculations).to have_key(:count)
+      end
+    end
+  end
+
+  describe '#method_missing' do
+    it 'sets calculation' do
+      prc = ->(_,_) { 1 }
+      instance.foo(&prc)
+      expect(instance.calculations[:foo]).to eq(prc)
+    end
+  end
+
+  describe '#calculation' do
+    before do
+      instance.count!
+    end
+
+    context 'when passed a symbol' do
+      it 'returns the calculation' do
+        expect(instance.calculation(:count)).to be_a(Proc)
+      end
+    end
+
+    context 'when passed a string' do
+      it 'returns the calculation' do
+        expect(instance.calculation('count')).to be_a(Proc)
+      end
+    end
+
+    context 'when no calculation found' do
+      it 'raises an error' do
+        expect { instance.calculation(:foo) }
+          .to raise_error(JsonapiCompliable::Errors::StatNotFound, "No stat configured for calculation :foo on attribute :myattr")
+      end
+    end
+  end
+end

--- a/spec/stats/payload_spec.rb
+++ b/spec/stats/payload_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe JsonapiCompliable::Stats::Payload do
+  let(:controller) { double.as_null_object }
+  let(:scope) { double.as_null_object }
+  let(:instance) { described_class.new(controller, scope) }
+  let(:params) { { stats: { attr1: 'count,average', attr2: 'maximum' } } }
+  let(:dsl) { double }
+
+  before do
+    allow(controller).to receive(:params) { params }
+    allow(controller).to receive(:_jsonapi_compliable) { dsl }
+  end
+
+  describe '#generate' do
+    subject { instance.generate }
+
+    def stub_stat(attr, calc, result)
+      allow(dsl).to receive(:stat).with(attr, calc) { ->(_,_) { result } }
+    end
+
+    before do
+      stub_stat(:attr1, :count, 2)
+      stub_stat(:attr1, :average, 1)
+      stub_stat(:attr2, :maximum, 3)
+    end
+
+    it 'generates the correct payload for each requested stat' do
+      expect(subject).to eq({
+        attr1: { count: 2, average: 1 },
+        attr2: { maximum: 3 }
+      })
+    end
+  end
+
+  describe '.new' do
+    it 'derives scope from controller' do
+      instance = described_class.new(controller, 'a')
+      expect(instance.instance_variable_get(:@scope))
+        .to eq(controller._jsonapi_scope)
+    end
+
+    context 'when scope not on controller' do
+      before do
+        allow(controller).to receive(:_jsonapi_scope) { nil }
+      end
+
+      it 'uses that scope' do
+        instance = described_class.new(controller, 'a')
+        expect(instance.instance_variable_get(:@scope))
+          .to eq('a')
+      end
+    end
+  end
+end

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -1,0 +1,172 @@
+require 'spec_helper'
+
+RSpec.describe 'stats', type: :controller do
+  controller(ApplicationController) do
+    jsonapi do
+      allow_stat total: :count
+
+      allow_stat state_id: [:sum, :average, :maximum, :minimum] do
+        second { |scope| scope.all[1].state_id }
+      end
+
+      allow_stat :just_symbol do
+        foo { 'bar' }
+      end
+
+      allow_stat :override do
+        sum { |scope, attr| 101 }
+      end
+    end
+
+    def index
+      render_ams(Author.all, meta: { other: 'things' })
+    end
+  end
+
+  let!(:author1) { Author.create!(first_name: 'Stephen', last_name: 'King', state_id: 1) }
+  let!(:author2) { Author.create!(first_name: 'Stephen', last_name: 'King', state_id: 3) }
+
+  context 'when total count requested' do
+    it 'responds with count in meta stats' do
+      get :index, params: { stats: { total: 'count' } }
+
+      expect(json['meta']['stats']).to eq({ 'total' => { 'count' => 2 } })
+    end
+
+    it 'does not override other meta content' do
+      get :index, params: { stats: { total: 'count' } }
+
+      expect(json['meta']['other']).to eq('things')
+    end
+  end
+
+  context 'when specific attribute requested' do
+    context 'when sum' do
+      it 'responds with sum in meta stats' do
+        get :index, params: { stats: { state_id: 'sum' } }
+
+        expect(json['meta']['stats']).to eq({ 'state_id' => { 'sum' => 4 } })
+      end
+    end
+
+    context 'when average' do
+      it 'responds with average in meta stats' do
+        get :index, params: { stats: { state_id: 'average' } }
+
+        expect(json['meta']['stats']).to eq({ 'state_id' => { 'average' => 2.0 } })
+      end
+    end
+
+    context 'when maximum' do
+      it 'responds with average in meta stats' do
+        get :index, params: { stats: { state_id: 'average' } }
+
+        expect(json['meta']['stats']).to eq({ 'state_id' => { 'average' => 2.0 } })
+      end
+    end
+
+    context 'when minimum' do
+      it 'responds with minimum in meta stats' do
+        get :index, params: { stats: { state_id: 'minimum' } }
+
+        expect(json['meta']['stats']).to eq({ 'state_id' => { 'minimum' => 1 } })
+      end
+    end
+
+    context 'when user-specified calculation' do
+      it 'responds with user-specified calculation in meta stats' do
+        get :index, params: { stats: { state_id: 'maximum' } }
+
+        expect(json['meta']['stats']).to eq({ 'state_id' => { 'maximum' => 3 } })
+      end
+    end
+
+    context 'when multiple stats requested' do
+      it 'responds with both' do
+        get :index, params: { stats: { total: 'count', state_id: 'sum,average' } }
+
+        expect(json['meta']['stats']).to eq({
+          'total' => { 'count' => 2 },
+          'state_id' => { 'sum' => 4, 'average' => 2.0 }
+        })
+      end
+    end
+  end
+
+  context 'when passing symbol to allow_stat' do
+    it 'works correctly' do
+      get :index, params: { stats: { just_symbol: 'foo' } }
+
+      expect(json['meta']['stats']).to eq({
+        'just_symbol' => { 'foo' => 'bar' }
+      })
+    end
+  end
+
+  context 'when no stats requested' do
+    it 'should not be in payload' do
+      get :index
+
+      expect(json['meta']).to eq({ 'other' => 'things' })
+    end
+  end
+
+  context 'when pagination requested' do
+    it 'should not affect the stats' do
+      get :index, params: { stats: { total: 'count' }, page: { size: 1, number: 1 } }
+
+      expect(json['meta']['stats']).to eq({ 'total' => { 'count' => 2 } })
+    end
+  end
+
+  context 'overriding a default' do
+    it 'should return the override' do
+      get :index, params: { stats: { override: 'sum' } }
+
+      expect(json['meta']['stats']).to eq({ 'override' => { 'sum' => 101 } })
+    end
+  end
+
+  context 'requesting ONLY stats' do
+    def only_stats
+      get :index, params: { stats: { total: 'count' }, page: { size: 0 } }
+    end
+
+    it 'returns empty data' do
+      only_stats
+      expect(json['data']).to be_empty
+    end
+
+    it 'does not query DB' do
+      expect(Author).to_not receive(:find_by_sql)
+      only_stats
+    end
+
+    it 'returns correct stats' do
+      only_stats
+      expect(json['meta']['stats']).to eq({ 'total' => { 'count' => 2 } })
+    end
+  end
+
+  context 'when not AR scope' do
+    before do
+      controller.class_eval do
+        jsonapi do
+          allow_stat :total do
+            count { |scope| scope.length }
+          end
+        end
+
+        def index
+          render_ams([Author.first])
+        end
+      end
+    end
+
+    it 'should stil allow custom stats' do
+      get :index, params: { stats: { total: 'count' } }
+
+      expect(json['meta']['stats']).to eq({ 'total' => { 'count' => 1 } })
+    end
+  end
+end

--- a/spec/util/pagination_spec.rb
+++ b/spec/util/pagination_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe JsonapiCompliable::Util::Pagination do
+  describe '.zero?' do
+    subject { described_class.zero?(params) }
+
+    context 'when no page specified' do
+      let(:params) { { } }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when params symbolized' do
+      context 'when page size is 0' do
+        let(:params) { { page: { size: 0 } } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when page size is "0"' do
+        let(:params) { { page: { size: '0' } } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when page size > 0 as string' do
+        let(:params) { { page: { size: '1' } } }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'when page size > 0 as integer' do
+        let(:params) { { page: { size: 1 } } }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context 'when params stringified' do
+      context 'when page size is 0' do
+        let(:params) { { 'page' => { 'size' => 0 } } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when page size is "0"' do
+        let(:params) { { 'page' => { 'size' => '0' } } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when page size > 0 as string' do
+        let(:params) { { 'page' => { 'size' => '1' } } }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'when page size > 0 as integer' do
+        let(:params) { { 'page' => { 'size' => 1 } } }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+end

--- a/spec/util/scoping_spec.rb
+++ b/spec/util/scoping_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe JsonapiCompliable::Util::Scoping do
     subject { described_class.apply?(controller, object, force) }
 
     before do
-      allow(controller).to receive(:_jsonapi_scoped) { nil }
+      allow(controller).to receive(:_jsonapi_scope) { nil }
     end
 
     it { is_expected.to be(true) }
@@ -22,7 +22,7 @@ RSpec.describe JsonapiCompliable::Util::Scoping do
 
     context 'when controller has already scoped' do
       before do
-        allow(controller).to receive(:_jsonapi_scoped) { true }
+        allow(controller).to receive(:_jsonapi_scope) { Author.where(name: 'asdf') }
       end
 
       it { is_expected.to be(false) }


### PR DESCRIPTION
Adds ability to calculate stats in 'meta' against the scope. eg:

`GET /api/v1/posts?stats[total]=count&stats[rank]=average,maximum`

returns

```ruby
{
  data: [],
  meta: {
    stats: {
      total: { count: 100 },
      rank: { average: 3.3, maximum: 10 }
    }
  }
}
```