### PR TITLE
Use reverse merge to avoid squashing data document parameters

### DIFF
--- a/lib/jsonapi_compliable/deserializable.rb
+++ b/lib/jsonapi_compliable/deserializable.rb
@@ -61,7 +61,7 @@ module JsonapiCompliable
         hash = attributes
         hash = hash.merge(relationships)
         hash = @namespace ? { parsed_type => hash } : hash
-        hash.merge(@params.except(:data)).deep_symbolize_keys
+        hash.reverse_merge(@params.except(:data)).deep_symbolize_keys
       end
 
       private

--- a/spec/deserialization_spec.rb
+++ b/spec/deserialization_spec.rb
@@ -60,5 +60,11 @@ RSpec.describe 'deserialization' do
       }
       expect(instance.params).to eq(expected)
     end
+
+    it 'does not overwrite deserialized param namespace with something from raw params' do
+      payload[:author] = 'Claudia y Inez Bachman'
+      instance.deserialize_jsonapi!
+      expect(instance.params[:author]).to be_a(Hash)
+    end
   end
 end


### PR DESCRIPTION
I ran into an issue in my development, where I have a resource called "actions" and could not update my data, instead getting a strange error... 

```
NoMethodError: undefined method `permit' for "update":String
./app/controllers/actions_controller.rb:33:in `update'
```

What?

After some time, I came to understand that this was coming from the default `ActionController::Parameters` hash, which includes such nice context as: `controller: "actions"` and `action: "update"`. 

What happens is that when `JsonapiCompliable::Deserializer` runs through the `data` hash, it singularizes the jsonapi type, and namespaces the result of the further transformations under that key in a new params hash... and then merges the original params on top. So then it collides with `action` from the original params, and is overwritten.

In this PR I change it to `reverse_merge` to avoid overwriting our subject data with random preserved context. However, a better solution here would be to namespace the deserialized params under some unique key.

Unfortunately I don't yet know enough about this ecosystem of gems to know whether that namespacing can be controlled by `JsonapiCompliable` or if it will run afoul of assumptions in `strong_resources`. 