### PR TITLE
Add support for polymorphic writes

### DIFF
--- a/lib/jsonapi_compliable/adapters/active_record_sideloading.rb
+++ b/lib/jsonapi_compliable/adapters/active_record_sideloading.rb
@@ -47,7 +47,7 @@ module JsonapiCompliable
       def has_one(association_name, scope: nil, resource:, foreign_key:, primary_key: :id, &blk)
         _scope = scope
 
-        allow_sideload association_name, resource: resource do
+        allow_sideload association_name, type: :has_one, foreign_key: foreign_key, primary_key: primary_key, resource: resource do
           scope do |parents|
             parent_ids = parents.map { |p| p.send(primary_key) }
             _scope.call.where(foreign_key => parent_ids.uniq.compact)
@@ -71,7 +71,7 @@ module JsonapiCompliable
         fk      = foreign_key.values.first
         _scope  = scope
 
-        allow_sideload association_name, resource: resource do
+        allow_sideload association_name, type: :habtm, foreign_key: foreign_key, primary_key: primary_key, resource: resource do
           scope do |parents|
             parent_ids = parents.map { |p| p.send(primary_key) }
             parent_ids.uniq!
@@ -94,14 +94,14 @@ module JsonapiCompliable
       end
 
       def polymorphic_belongs_to(association_name, group_by:, groups:, &blk)
-        allow_sideload association_name, polymorphic: true do
-          group_by(&group_by)
+        allow_sideload association_name, type: :polymorphic_belongs_to, polymorphic: true do
+          group_by(group_by)
 
           groups.each_pair do |type, config|
             primary_key = config[:primary_key] || :id
             foreign_key = config[:foreign_key]
 
-            allow_sideload type, resource: config[:resource] do
+            allow_sideload type, parent: self, primary_key: primary_key, foreign_key: foreign_key, type: :belongs_to, resource: config[:resource] do
               scope do |parents|
                 parent_ids = parents.map { |p| p.send(foreign_key) }
                 parent_ids.compact!

--- a/lib/jsonapi_compliable/util/relationship_payload.rb
+++ b/lib/jsonapi_compliable/util/relationship_payload.rb
@@ -43,8 +43,14 @@ module JsonapiCompliable
       end
 
       def payload_for(sideload, relationship_payload)
+        if sideload.polymorphic?
+          type     = relationship_payload[:meta][:jsonapi_type]
+          sideload = sideload.polymorphic_child_for_type(type)
+        end
+
         {
           sideload: sideload,
+          is_polymorphic: !sideload.parent.nil?,
           primary_key: sideload.primary_key,
           foreign_key: sideload.foreign_key,
           attributes: relationship_payload[:attributes],

--- a/lib/jsonapi_compliable/util/validation_response.rb
+++ b/lib/jsonapi_compliable/util/validation_response.rb
@@ -33,7 +33,8 @@ class JsonapiCompliable::Util::ValidationResponse
   private
 
   def valid_object?(object)
-    object.respond_to?(:errors) && object.errors.blank?
+    !object.respond_to?(:errors) ||
+      (object.respond_to?(:errors) && object.errors.blank?)
   end
 
   def all_valid?(model, deserialized_params)

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -86,7 +86,7 @@ if ENV["APPRAISAL_INITIALIZED"]
           foreign_key: { author_hobbies: :author_id }
 
         polymorphic_belongs_to :dwelling,
-          group_by: proc { |author| author.dwelling_type },
+          group_by: :dwelling_type,
           groups: {
             'House' => {
               foreign_key: :dwelling_id,

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe JsonapiCompliable::Sideload do
       end
 
       before do
-        instance.group_by { |parent| parent[:type] }
+        instance.group_by :type
 
         instance.allow_sideload 'foo', resource: foo_resource do
           scope { |parents| [{ parent_id: 1 }] }
@@ -143,6 +143,30 @@ RSpec.describe JsonapiCompliable::Sideload do
       it 'does not add to sideloads' do
         instance.allow_sideload :bar
         expect(instance.sideloads).to be_empty
+      end
+    end
+  end
+
+  describe '#associate' do
+    before do
+      instance.instance_variable_set(:@type, :has_many)
+    end
+
+    it 'delegates to adapter' do
+      expect(instance.resource_class.config[:adapter])
+        .to receive(:associate).with('parent', 'child', :foo, :has_many)
+      instance.associate('parent', 'child')
+    end
+
+    context 'when a polymorphic child' do
+      before do
+        instance.instance_variable_set(:@parent, double(name: :parent_name))
+      end
+
+      it 'passes parent name as association name' do
+        expect(instance.resource_class.config[:adapter])
+          .to receive(:associate).with('parent', 'child', :parent_name, :has_many)
+        instance.associate('parent', 'child')
       end
     end
   end

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'sideloading' do
 
     _dwelling_resource = dwelling_resource
     resource_class.allow_sideload :dwelling, polymorphic: true do
-      group_by { |author| binding.pry;author[:dwelling_type] }
+      group_by :dwelling_type
 
       allow_sideload 'House', resource: _dwelling_resource do
         scope do |authors|
@@ -201,7 +201,7 @@ RSpec.describe 'sideloading' do
 
       _dwelling_resource = dwelling_resource
       resource_class.allow_sideload :dwelling, polymorphic: true do
-        group_by { |author| author[:dwelling_type] }
+        group_by :dwelling_type
 
         allow_sideload 'House', resource: _dwelling_resource do
           scope do |authors|


### PR DESCRIPTION
This changes the polymorphic grouper to a symbol instead of a proc. Proc
was only used for when the object was a hash, so this is instead handled
manually.