### PR TITLE
Pin jsonapi-rb gems.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,11 @@
 appraise "rails-4" do
   gem "rails", "~> 4.1"
-  gem 'jsonapi-rails', '~> 0.1', require: 'jsonapi/rails'
+  gem 'jsonapi-rails', '~> 0.1.0', require: 'jsonapi/rails'
   gem 'rspec-rails'
 end
 
 appraise "rails-5" do
   gem "rails", "~> 5.0"
-  gem 'jsonapi-rails', '~> 0.1', require: 'jsonapi/rails'
+  gem 'jsonapi-rails', '~> 0.1.0', require: 'jsonapi/rails'
   gem 'rspec-rails'
 end

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -3,15 +3,15 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1"
-gem "jsonapi-rails", "~> 0.1.0", require: "jsonapi/rails"
+gem "jsonapi-rails", "~> 0.1.0", :require => "jsonapi/rails"
 gem "rspec-rails"
 
 group :test do
   gem "pry"
-  gem "pry-byebug", platform: [:mri]
+  gem "pry-byebug", :platform => [:mri]
   gem "appraisal"
   gem "guard"
   gem "guard-rspec"
 end
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -3,15 +3,15 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1"
-gem "jsonapi-rails", "~> 0.1", :require => "jsonapi/rails"
+gem "jsonapi-rails", "~> 0.1.0", require: "jsonapi/rails"
 gem "rspec-rails"
 
 group :test do
   gem "pry"
-  gem "pry-byebug", :platform => [:mri]
+  gem "pry-byebug", platform: [:mri]
   gem "appraisal"
   gem "guard"
   gem "guard-rspec"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,16 +2,16 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0"
-gem "jsonapi-rails", "~> 0.1.0", require: "jsonapi/rails"
+gem "rails", ['>= 5.0', '< 5.1']
+gem "jsonapi-rails", "~> 0.1.0", :require => "jsonapi/rails"
 gem "rspec-rails"
 
 group :test do
   gem "pry"
-  gem "pry-byebug", platform: [:mri]
+  gem "pry-byebug", :platform => [:mri]
   gem "appraisal"
   gem "guard"
   gem "guard-rspec"
 end
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,16 +2,16 @@
 
 source "https://rubygems.org"
 
-gem "rails", ['>= 5.0', '< 5.1']
-gem "jsonapi-rails", "~> 0.1", :require => "jsonapi/rails"
+gem "rails", "~> 5.0"
+gem "jsonapi-rails", "~> 0.1.0", require: "jsonapi/rails"
 gem "rspec-rails"
 
 group :test do
   gem "pry"
-  gem "pry-byebug", :platform => [:mri]
+  gem "pry-byebug", platform: [:mri]
   gem "appraisal"
   gem "guard"
   gem "guard-rspec"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/jsonapi_compliable.gemspec
+++ b/jsonapi_compliable.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jsonapi-serializable', '~> 0.1'
+  spec.add_dependency 'jsonapi-serializable', '~> 0.1.0'
 
   spec.add_development_dependency "activerecord", ['>= 4.1', '< 6']
   spec.add_development_dependency "kaminari", '~> 0.17'


### PR DESCRIPTION
Currently, `jsonapi_compliable` relies on `jsonapi-serializable '~> 0.1'`. This PR pins it down to `~> 0.1.0`.