### PR TITLE
Allow sideload to be referenced multiple times

### DIFF
--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -310,7 +310,10 @@ module JsonapiCompliable
     # @return [Hash] The nested include hash
     # @api private
     def to_hash(processed = [])
-      return { name => {} } if processed.include?(self)
+      # Cut off at 5 recursions
+      if processed.select { |p| p == self }.length == 5
+        return { name => {} }
+      end
       processed << self
 
       result = { name => {} }.tap do |hash|


### PR DESCRIPTION
If the same resource was sideloaded twice, the next level of sideloading
would only apply once. This fixes that logic to allow this up to five
times (without cutoff there is infinite recursion).

Fixes https://github.com/jsonapi-suite/jsonapi_compliable/issues/41