### PR TITLE
Prevent non-resource backed controller from throwing no method error when mix-in is inherited from ApplicationController

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -64,7 +64,7 @@ module JsonapiCompliable
     #
     # @return [Resource] the configured Resource for this controller
     def jsonapi_resource
-      @jsonapi_resource ||= self.class._jsonapi_compliable.new
+      @jsonapi_resource ||= self.class._jsonapi_compliable ? self.class._jsonapi_compliable.new : JsonapiCompliable::Resource.new
     end
 
     # Instantiates the relevant Query object


### PR DESCRIPTION
Change to allow 'include JsonapiSuite::ControllerMixin' to be called directly from ApplicationController without needing to specify 'jsonapi resource: < name >' in every descendant controller.

Fix for https://github.com/jsonapi-suite/jsonapi_compliable/issues/45