### PR TITLE
Add support for HABTM writes

### DIFF
--- a/lib/jsonapi_compliable/adapters/abstract.rb
+++ b/lib/jsonapi_compliable/adapters/abstract.rb
@@ -237,6 +237,46 @@ module JsonapiCompliable
         raise 'you must override #associate in an adapter subclass'
       end
 
+      # Remove the association without destroying objects
+      #
+      # This is NOT needed in the standard use case. The standard use case would be:
+      #
+      #   def update(attrs)
+      #     # attrs[:the_foreign_key] is nil, so updating the record disassociates
+      #   end
+      #
+      # However, sometimes you need side-effect or elsewise non-standard behavior. Consider
+      # using {{https://github.com/mbleigh/acts-as-taggable-on acts_as_taggable_on}} gem:
+      #
+      #   # Not actually needed, just an example
+      #   def disassociate(parent, child, association_name, association_type)
+      #     parent.tag_list.remove(child.name)
+      #   end
+      #
+      # @example Basic accessor
+      #   def disassociate(parent, child, association_name, association_type)
+      #     if association_type == :has_many
+      #       parent.send(association_name).delete(child)
+      #     else
+      #       child.send(:"#{association_name}=", nil)
+      #     end
+      #   end
+      #
+      # +association_name+ and +association_type+ come from your sideload
+      # configuration:
+      #
+      #   allow_sideload :the_name, type: the_type do
+      #     # ... code.
+      #   end
+      #
+      # @param parent The parent object (via the JSONAPI 'relationships' graph)
+      # @param child The child object (via the JSONAPI 'relationships' graph)
+      # @param association_name The 'relationships' key we are processing
+      # @param association_type The Sideload type (see Sideload#type). Usually :has_many/:belongs_to/etc
+      def disassociate(parent, child, association_name, association_type)
+        raise 'you must override #disassociate in an adapter subclass'
+      end
+
       # This module gets mixed in to Sideload classes
       # This is where you define methods like has_many,
       # belongs_to etc that wrap the lower-level Sideload#allow_sideload

--- a/lib/jsonapi_compliable/adapters/active_record.rb
+++ b/lib/jsonapi_compliable/adapters/active_record.rb
@@ -75,8 +75,21 @@ module JsonapiCompliable
         if association_type == :has_many
           parent.association(association_name).loaded!
           parent.association(association_name).add_to_target(child, :skip_callbacks)
+        elsif association_type == :habtm
+          parent.send(association_name) << child
         else
           child.send("#{association_name}=", parent)
+        end
+      end
+
+      # When a has_and_belongs_to_many relationship, we don't have a foreign
+      # key that can be null'd. Instead, go through the ActiveRecord API.
+      # @see Adapters::Abstract#disassociate
+      def disassociate(parent, child, association_name, association_type)
+        if association_type == :habtm
+          parent.send(association_name).delete(child)
+        else
+          # Nothing to do here, happened when we merged foreign key
         end
       end
 

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -543,10 +543,28 @@ module JsonapiCompliable
       adapter.destroy(model, id)
     end
 
+    # Delegates #associate to adapter. Built for overriding.
+    #
+    # @see .use_adapter
+    # @see Adapters::Abstract#associate
+    # @see Adapters::ActiveRecord#associate
+    def associate(parent, child, association_name, type)
+      adapter.associate(parent, child, association_name, type)
+    end
+
+    # Delegates #disassociate to adapter. Built for overriding.
+    #
+    # @see .use_adapter
+    # @see Adapters::Abstract#disassociate
+    # @see Adapters::ActiveRecord#disassociate
+    def disassociate(parent, child, association_name, type)
+      adapter.disassociate(parent, child, association_name, type)
+    end
+
     # @api private
-    def persist_with_relationships(meta, attributes, relationships)
+    def persist_with_relationships(meta, attributes, relationships, caller_model = nil)
       persistence = JsonapiCompliable::Util::Persistence \
-        .new(self, meta, attributes, relationships)
+        .new(self, meta, attributes, relationships, caller_model)
       persistence.run
     end
 

--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -170,24 +170,25 @@ module JsonapiCompliable
     end
 
     # Configure how to associate parent and child records.
-    #
-    # @example Basic attr_accessor
-    #   def associate(parent, child)
-    #     if type == :has_many
-    #       parent.send(:"#{name}").push(child)
-    #     else
-    #       child.send(:"#{name}=", parent)
-    #     end
-    #   end
+    # Delegates to #resource
     #
     # @see #name
     # @see #type
+    # @api private
     def associate(parent, child)
       association_name = @parent ? @parent.name : name
-      resource_class.config[:adapter].associate parent,
-        child,
-        association_name,
-        type
+      resource.associate(parent, child, association_name, type)
+    end
+
+    # Configure how to disassociate parent and child records.
+    # Delegates to #resource
+    #
+    # @see #name
+    # @see #type
+    # @api private
+    def disassociate(parent, child)
+      association_name = @parent ? @parent.name : name
+      resource.disassociate(parent, child, association_name, type)
     end
 
     # Define an attribute that groups the parent records. For instance, with


### PR DESCRIPTION
Adds `disassociate` method to resource/adapter, which mirrors
`associate`. This will be helpful in other contexts as well.