### PR TITLE
Don't raise on missing data payload

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -243,7 +243,7 @@ module JsonapiCompliable
     private
 
     def force_includes?
-      not deserialized_params.data.nil?
+      not deserialized_params.data.empty?
     end
 
     def perform_render_jsonapi(opts)

--- a/lib/jsonapi_compliable/deserializer.rb
+++ b/lib/jsonapi_compliable/deserializer.rb
@@ -55,7 +55,7 @@ class JsonapiCompliable::Deserializer
 
   # @return [Hash] the raw :data value of the payload
   def data
-    @payload[:data]
+    @payload[:data] || {}
   end
 
   # @return [String] the raw :id value of the payload

--- a/spec/deserializer_spec.rb
+++ b/spec/deserializer_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe JsonapiCompliable::Deserializer do
 
   let(:instance) { described_class.new(payload, {}) }
 
+  describe '#data' do
+    subject { instance.data }
+
+    context 'when data is present' do
+      it 'returns the proper sub-object' do
+        expect(subject).to eq(payload[:data])
+      end
+    end
+
+    context 'when data is absent' do
+      let(:payload) do
+        {
+            foo: 'bar'
+        }
+      end
+
+      it 'returns an empty hash' do
+        expect(subject).to eq({})
+      end
+    end
+  end
+
   describe '#attributes' do
     subject { instance.attributes }
 
@@ -29,6 +51,18 @@ RSpec.describe JsonapiCompliable::Deserializer do
 
       it 'merges id into attributes' do
         expect(subject[:id]).to eq('123')
+      end
+    end
+
+    context 'when data is absent' do
+      let(:payload) do
+        {
+            foo: 'bar'
+        }
+      end
+
+      it 'returns an empty hash' do
+        expect(subject).to eq({})
       end
     end
   end


### PR DESCRIPTION
Let data return an empty hash instead. Added corresponding specs.

Tested with appraisal rspec and found no errors.