### PR TITLE
Implement has_one association for ActiveRecord Adapter

### DIFF
--- a/lib/jsonapi_compliable/adapters/active_record.rb
+++ b/lib/jsonapi_compliable/adapters/active_record.rb
@@ -80,6 +80,8 @@ module JsonapiCompliable
           else
             parent.send(association_name) << child
           end
+        elsif association_type == :has_one
+          parent.send("#{association_name}=", child)
         elsif
           child.send("#{association_name}=", parent)
         end

--- a/lib/jsonapi_compliable/version.rb
+++ b/lib/jsonapi_compliable/version.rb
@@ -1,3 +1,3 @@
 module JsonapiCompliable
-  VERSION = "0.10.7"
+  VERSION = "0.10.8"
 end

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :salaries do |t|
     t.integer :employee_id
     t.decimal :base_rate
-    t.decimal :over_time_rate
+    t.decimal :overtime_rate
   end
 end
 
@@ -229,5 +229,5 @@ class SerializableSalary < SerializableAbstract
   type 'salaries'
 
   attribute :base_rate
-  attribute :over_time_rate
+  attribute :overtime_rate
 end

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -159,9 +159,9 @@ class EmployeeResource < ApplicationResource
     scope: -> { Team.all },
     foreign_key: { employee_teams: :employee_id }
   has_one :salary,
-          scope: -> { Salary.all },
-          foreign_key: :employee_id,
-          resource: SalaryResource
+    resource: SalaryResource,
+    scope: -> { Salary.all },
+    foreign_key: :employee_id
 
   polymorphic_belongs_to :workspace,
     group_by: :workspace_type,

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -38,6 +38,12 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :departments do |t|
     t.string :name
   end
+
+  create_table :salaries do |t|
+    t.integer :employee_id
+    t.decimal :base_rate
+    t.decimal :over_time_rate
+  end
 end
 
 class ApplicationRecord < ActiveRecord::Base
@@ -75,6 +81,8 @@ class Employee < ApplicationRecord
 
   has_many :employee_teams
   has_many :teams, through: :employee_teams
+
+  has_one :salary
 end
 
 class Position < ApplicationRecord
@@ -84,6 +92,10 @@ end
 
 class Department < ApplicationRecord
   has_many :positions
+end
+
+class Salary < ApplicationRecord
+  belongs_to :employee
 end
 
 class ApplicationResource < JsonapiCompliable::Resource
@@ -125,6 +137,11 @@ class HomeOfficeResource < ApplicationResource
   model HomeOffice
 end
 
+class SalaryResource < ApplicationResource
+  type :salaries
+  model Salary
+end
+
 class EmployeeResource < ApplicationResource
   type :employees
   model Employee
@@ -141,6 +158,10 @@ class EmployeeResource < ApplicationResource
     resource: TeamResource,
     scope: -> { Team.all },
     foreign_key: { employee_teams: :employee_id }
+  has_one :salary,
+          scope: -> { Salary.all },
+          foreign_key: :employee_id,
+          resource: SalaryResource
 
   polymorphic_belongs_to :workspace,
     group_by: :workspace_type,
@@ -183,6 +204,8 @@ class SerializableEmployee < SerializableAbstract
   belongs_to :classification
   has_many :positions
   has_many :teams
+
+  has_one :salary
 end
 
 class SerializablePosition < SerializableAbstract
@@ -200,4 +223,11 @@ class SerializableDepartment < SerializableAbstract
   attribute :name
 
   has_many :positions
+end
+
+class SerializableSalary < SerializableAbstract
+  type 'salaries'
+
+  attribute :base_rate
+  attribute :over_time_rate
 end

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -187,6 +187,10 @@ if ENV["APPRAISAL_INITIALIZED"]
           expect {
             do_post
           }.to change { Salary.count }.by(1)
+
+          salary = Employee.first.salary
+          expect(salary.base_rate).to eq(15.0)
+          expect(salary.overtime_rate).to eq(30.0)
         end
       end
 
@@ -196,7 +200,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
         before do
           employee.salary = salary
-          employee.save
+          employee.save!
         end
 
         context 'on update' do
@@ -234,7 +238,6 @@ if ENV["APPRAISAL_INITIALIZED"]
           end
         end
 
-
         context 'on destroy' do
           let(:payload) do
             {
@@ -259,6 +262,7 @@ if ENV["APPRAISAL_INITIALIZED"]
             employee.reload
 
             expect(employee.salary).to be_nil
+            expect { salary.reload }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
 

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -48,7 +48,7 @@ if ENV["APPRAISAL_INITIALIZED"]
     end
 
     def do_put(id)
-      put :update, params: payload.merge(id: id)
+      put :update, params: payload
     end
 
     before do
@@ -146,6 +146,148 @@ if ENV["APPRAISAL_INITIALIZED"]
         delete :destroy, params: { id: employee.id }
         expect(json_item['id']).to eq(employee.id.to_s)
         expect(json_item['first_name']).to eq('Joe')
+      end
+    end
+
+    describe 'has_one nested relationship' do
+      context 'for new records' do
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              attributes: {
+                first_name: 'Joe',
+                last_name: 'Smith',
+                age: 30
+              },
+              relationships: {
+                salary: {
+                  data: {
+                    :'temp-id' => 'abc123',
+                    type: 'salaries',
+                    method: 'create'
+                  },
+                }
+              }
+            },
+            included: [
+              {
+                :'temp-id' => 'abc123',
+                type: 'salaries',
+                attributes: {
+                  base_rate: 15.00,
+                  over_time_rate: 30.00
+                }
+              }
+            ]
+          }
+        end
+
+        it 'can create' do
+          expect {
+            do_post
+          }.to change { Salary.count }.by(1)
+        end
+      end
+
+      context 'for existing records' do
+        let(:employee) { Employee.create!(first_name: 'Joe') }
+        let(:salary) { Salary.new(base_rate: 15.0, over_time_rate: 30.00) }
+
+        before do
+          employee.salary = salary
+          employee.save
+        end
+
+        context 'on update' do
+          let(:payload) do
+            {
+              data: {
+                id: employee.id,
+                type: 'employees',
+                relationships: {
+                  salary: {
+                    data: {
+                      id: salary.id,
+                      type: 'salaries',
+                      method: 'update'
+                    },
+                  }
+                }
+              },
+              included: [
+                {
+                  id: salary.id,
+                  type: 'salaries',
+                  attributes: {
+                    base_rate: 15.75
+                  }
+                }
+              ]
+            }
+          end
+
+          it 'can update' do
+            expect {
+              do_put(employee.id)
+            }.to change { employee.reload.salary.base_rate }.from(15.0).to(15.75)
+          end
+        end
+
+
+        context 'on destroy' do
+          let(:payload) do
+            {
+              data: {
+                id: employee.id,
+                type: 'employees',
+                relationships: {
+                  salary: {
+                    data: {
+                      id: salary.id,
+                      type: 'salaries',
+                      method: 'destroy'
+                    }
+                  }
+                }
+              }
+            }
+          end
+
+          it 'can destroy' do
+            do_put(employee.id)
+            employee.reload
+
+            expect(employee.salary).to be_nil
+          end
+        end
+
+        context 'on disassociate' do
+          let(:payload) do
+            {
+              data: {
+                id: employee.id,
+                type: 'employees',
+                relationships: {
+                  salary: {
+                    data: {
+                      id: salary.id,
+                      type: 'salaries',
+                      method: 'disassociate'
+                    }
+                  }
+                }
+              }
+            }
+          end
+
+          it 'can disassociate' do
+            do_put(employee.id)
+            salary.reload
+
+            expect(salary.employee_id).to be_nil
+          end
+        end
       end
     end
 

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -176,7 +176,7 @@ if ENV["APPRAISAL_INITIALIZED"]
                 type: 'salaries',
                 attributes: {
                   base_rate: 15.00,
-                  over_time_rate: 30.00
+                  overtime_rate: 30.00
                 }
               }
             ]
@@ -192,7 +192,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
       context 'for existing records' do
         let(:employee) { Employee.create!(first_name: 'Joe') }
-        let(:salary) { Salary.new(base_rate: 15.0, over_time_rate: 30.00) }
+        let(:salary) { Salary.new(base_rate: 15.0, overtime_rate: 30.00) }
 
         before do
           employee.salary = salary


### PR DESCRIPTION
## Issue
`has_one` relationships don't work for the ActiveRecord Adapter

## Details
Within `lib/jsonapi_compliable/adapters/active_record.rb`, the `associate` method does not take into consideration `has_one` relationships. This results in the adapter hitting the final `elsif` and attempting to send `association_name` to the _child_, instead of the parent.

That means, for example, for the new model in this PR, you would end up seeing errors like:

`NoMethodError: undefined method 'salary=' for #<Salary:0x007fe9ff8d25e8>`