### PR TITLE
Allow scopes access to runtime context

### DIFF
--- a/lib/jsonapi_compliable/scoping/default_filter.rb
+++ b/lib/jsonapi_compliable/scoping/default_filter.rb
@@ -38,7 +38,7 @@ module JsonapiCompliable
     def apply
       resource.default_filters.each_pair do |name, opts|
         next if overridden?(name)
-        @scope = opts[:filter].call(@scope)
+        @scope = opts[:filter].call(@scope, resource.context)
       end
 
       @scope

--- a/lib/jsonapi_compliable/scoping/extra_fields.rb
+++ b/lib/jsonapi_compliable/scoping/extra_fields.rb
@@ -35,7 +35,7 @@ module JsonapiCompliable
     # @return the scope object we are chaining/modofying
     def apply
       each_extra_field do |callable|
-        @scope = callable.call(@scope)
+        @scope = callable.call(@scope, resource.context)
       end
 
       @scope

--- a/lib/jsonapi_compliable/scoping/filter.rb
+++ b/lib/jsonapi_compliable/scoping/filter.rb
@@ -41,7 +41,7 @@ module JsonapiCompliable
     # specified in the adapter.
     def filter_scope(filter, value)
       if custom_scope = filter.values.first[:filter]
-        custom_scope.call(@scope, value)
+        custom_scope.call(@scope, value, resource.context)
       else
         resource.adapter.filter(@scope, filter.keys.first, value)
       end

--- a/lib/jsonapi_compliable/scoping/paginate.rb
+++ b/lib/jsonapi_compliable/scoping/paginate.rb
@@ -61,7 +61,7 @@ module JsonapiCompliable
 
     # Apply the custom pagination proc
     def apply_custom_scope
-      custom_scope.call(@scope, number, size)
+      custom_scope.call(@scope, number, size, resource.context)
     end
 
     private

--- a/lib/jsonapi_compliable/scoping/sort.rb
+++ b/lib/jsonapi_compliable/scoping/sort.rb
@@ -31,7 +31,8 @@ module JsonapiCompliable
     # @return the scope we are chaining/modifying
     def apply_custom_scope
       each_sort do |attribute, direction|
-        @scope = custom_scope.call(@scope, attribute, direction)
+        @scope = custom_scope
+          .call(@scope, attribute, direction, resource.context)
       end
       @scope
     end

--- a/spec/extra_fields_spec.rb
+++ b/spec/extra_fields_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'extra_fields' do
     extra_attribute :net_worth, if: proc { !@context || @context.allow_net_worth? } do
       100_000_000
     end
+
+    extra_attribute :runtime_id do
+      @context.runtime_id
+    end
   end
 
   before do
@@ -16,12 +20,25 @@ RSpec.describe 'extra_fields' do
       extra_field :net_worth do |scope|
         scope.include_foo!
       end
+
+      extra_field :runtime_id do |scope, ctx|
+        scope.runtime_id = ctx.runtime_id
+        scope
+      end
     end
   end
 
   let!(:scope_object) do
     scope = Author.all
     scope.instance_eval do
+      def runtime_id=(val)
+        @runtime_id = val
+      end
+
+      def runtime_id
+        @runtime_id
+      end
+
       def include_foo!
         self
       end
@@ -51,6 +68,21 @@ RSpec.describe 'extra_fields' do
   it 'alters the scope based on the supplied block' do
     params[:extra_fields] = { authors: 'net_worth' }
     expect(json['data'][0]['attributes'].keys).to match_array(%w(first_name last_name net_worth))
+  end
+
+  context 'when accessing runtime context' do
+    before do
+      params[:extra_fields] = { authors: 'runtime_id' }
+    end
+
+    it 'works' do
+      expect(scope_object).to receive(:runtime_id=).with(789)
+      ctx = double(runtime_id: 789).as_null_object
+      resource.with_context ctx do
+        attrs = json['data'][0]['attributes']
+        expect(attrs['runtime_id']).to eq(789)
+      end
+    end
   end
 
   context 'when extra field is requested but guarded' do

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -52,5 +52,22 @@ RSpec.describe 'pagination' do
     it 'uses the custom pagination function' do
       expect(scope.resolve).to eq([])
     end
+
+    context 'and it accesses runtime context' do
+      before do
+        resource_class.class_eval do
+          paginate do |scope, page, per_page, ctx|
+            scope.limit(ctx.runtime_limit)
+          end
+        end
+      end
+
+      it 'works' do
+        ctx = double(runtime_limit: 2).as_null_object
+        JsonapiCompliable.with_context(ctx, {}) do
+          expect(scope.resolve.length).to eq(2)
+        end
+      end
+    end
   end
 end

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 RSpec.describe JsonapiCompliable::Scope do
   let(:object)     { double.as_null_object }
-  let(:resource)   { double(type: :authors, default_page_size: 1).as_null_object }
   let(:query_hash) { JsonapiCompliable::Query.default_hash }
   let(:query)      { double(to_hash: { authors: query_hash }) }
   let(:instance)   { described_class.new(object, resource, query) }
+
+  let(:resource) do
+    dbl = double type: :authors,
+      default_page_size: 1,
+      pagination: nil
+    dbl.as_null_object
+  end
 
   describe '#resolve' do
     before do

--- a/spec/sorting_spec.rb
+++ b/spec/sorting_spec.rb
@@ -75,6 +75,30 @@ RSpec.describe 'sorting' do
       it 'uses the custom sort function' do
         expect(scope.resolve.map(&:id)).to eq(Author.pluck(:id).reverse)
       end
+
+      context 'and it accesses runtime context' do
+        before do
+          resource_class.class_eval do
+            sort do |scope, att, dir, ctx|
+              scope.order(id: ctx.runtime_direction)
+            end
+          end
+        end
+
+        it 'works (desc)' do
+          ctx = double(runtime_direction: :desc).as_null_object
+          JsonapiCompliable.with_context(ctx, {}) do
+            expect(scope.resolve.map(&:id)).to eq(Author.pluck(:id).reverse)
+          end
+        end
+
+        it 'works (asc)' do
+          ctx = double(runtime_direction: :asc).as_null_object
+          JsonapiCompliable.with_context(ctx, {}) do
+            expect(scope.resolve.map(&:id)).to eq(Author.pluck(:id))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In Rails, this means scopes would run in the context of the controller.
So you can do things like:

```ruby
default_filter :foo do |scope|
  scope.where(user_id: current_user.id)
end
```