### PR TITLE
Add before_commit hooks

### DIFF
--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -24,6 +24,7 @@ require "jsonapi_compliable/util/relationship_payload"
 require "jsonapi_compliable/util/persistence"
 require "jsonapi_compliable/util/validation_response"
 require "jsonapi_compliable/util/sideload"
+require "jsonapi_compliable/util/hooks"
 
 # require correct jsonapi-rb before extensions
 if defined?(Rails)

--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -246,9 +246,20 @@ module JsonapiCompliable
       end
     end
 
+    # Delete the model
+    # Any error, including validation errors, will roll back the transaction.
+    #
+    # Note: +before_commit+ hooks still run unless excluded
+    #
+    # @return [Util::ValidationResponse]
     def jsonapi_destroy
-      _persist do
-        jsonapi_resource.destroy(params[:id])
+      jsonapi_resource.transaction do
+        model = jsonapi_resource.destroy(params[:id])
+        validator = ::JsonapiCompliable::Util::ValidationResponse.new \
+          model, deserialized_params
+        validator.validate!
+        jsonapi_resource.before_commit(model, :destroy)
+        validator
       end
     end
 
@@ -314,6 +325,18 @@ module JsonapiCompliable
 
     private
 
+    def _persist
+      jsonapi_resource.transaction do
+        ::JsonapiCompliable::Util::Hooks.record do
+          model = yield
+          validator = ::JsonapiCompliable::Util::ValidationResponse.new \
+            model, deserialized_params
+          validator.validate!
+          validator
+        end
+      end
+    end
+
     def force_includes?
       not deserialized_params.data.nil?
     end
@@ -322,17 +345,6 @@ module JsonapiCompliable
       # TODO(beauby): Reuse renderer.
       JSONAPI::Serializable::Renderer.new
         .render(opts.delete(:jsonapi), opts).to_json
-    end
-
-    def _persist
-      validation_response = nil
-      jsonapi_resource.transaction do
-        object = yield
-        validation_response = Util::ValidationResponse.new \
-          object, deserialized_params
-        raise Errors::ValidationError unless validation_response.to_a[1]
-      end
-      validation_response
     end
   end
 end

--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -1,7 +1,14 @@
 module JsonapiCompliable
   module Errors
     class BadFilter < StandardError; end
-    class ValidationError < StandardError; end
+
+    class ValidationError < StandardError
+      attr_reader :validation_response
+
+      def initialize(validation_response)
+        @validation_response = validation_response
+      end
+    end
 
     class UnsupportedPageSize < StandardError
       def initialize(size, max)

--- a/lib/jsonapi_compliable/util/hooks.rb
+++ b/lib/jsonapi_compliable/util/hooks.rb
@@ -1,0 +1,33 @@
+module JsonapiCompliable
+  module Util
+    class Hooks
+      def self.record
+        self.hooks = []
+        begin
+          yield.tap { run }
+        ensure
+          self.hooks = []
+        end
+      end
+
+      def self._hooks
+        Thread.current[:_compliable_hooks] ||= []
+      end
+      private_class_method :_hooks
+
+      def self.hooks=(val)
+        Thread.current[:_compliable_hooks] = val
+      end
+
+      # Because hooks will be added from the outer edges of
+      # the graph, working inwards
+      def self.add(prc)
+        _hooks.unshift(prc)
+      end
+
+      def self.run
+        _hooks.each { |h| h.call }
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/util/validation_response.rb
+++ b/lib/jsonapi_compliable/util/validation_response.rb
@@ -30,6 +30,13 @@ class JsonapiCompliable::Util::ValidationResponse
     [object, success?]
   end
 
+  def validate!
+    unless success?
+      raise ::JsonapiCompliable::Errors::ValidationError.new(self)
+    end
+    self
+  end
+
   private
 
   def valid_object?(object)

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -48,6 +48,21 @@ end
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  attr_accessor :force_validation_error
+
+  before_save do
+    add_validation_error if force_validation_error
+
+    if Rails::VERSION::MAJOR >= 5
+      throw(:abort) if errors.present?
+    else
+      errors.blank?
+    end
+  end
+
+  def add_validation_error
+    errors.add(:base, 'Forced validation error')
+  end
 end
 
 class Classification < ApplicationRecord
@@ -74,8 +89,6 @@ class HomeOffice < ApplicationRecord
 end
 
 class Employee < ApplicationRecord
-  attr_accessor :force_validation_error
-
   belongs_to :workspace, polymorphic: true
   belongs_to :classification
   has_many :positions
@@ -97,10 +110,6 @@ class Employee < ApplicationRecord
     else
       errors.blank?
     end
-  end
-
-  def add_validation_error
-    errors.add(:base, 'Forced validation error')
   end
 end
 

--- a/spec/integration/rails/before_commit_spec.rb
+++ b/spec/integration/rails/before_commit_spec.rb
@@ -1,0 +1,220 @@
+if ENV["APPRAISAL_INITIALIZED"]
+  require 'rails_spec_helper'
+
+  RSpec.describe 'before_commit hook', type: :controller do
+    class Callbacks
+      class << self
+        attr_accessor :fired, :entities
+      end
+
+      def self.add(name, object)
+        self.fired[name] = object
+        self.entities << name
+      end
+    end
+
+    before do
+      Callbacks.fired = {}
+      Callbacks.entities = []
+      $raise_on_before_commit = { employee: true }
+    end
+
+    module IntegrationHooks
+      class ApplicationResource < JsonapiCompliable::Resource
+        use_adapter JsonapiCompliable::Adapters::ActiveRecord
+      end
+
+      class DepartmentResource < ApplicationResource
+        type :departments
+        model Department
+
+        before_commit do |department|
+          Callbacks.add(:department, department)
+          if $raise_on_before_commit[:department]
+            raise 'rollitback_department'
+          end
+        end
+      end
+
+      class PositionResource < ApplicationResource
+        type :positions
+        model Position
+
+        before_commit do |position|
+          Callbacks.add(:position, position)
+          if $raise_on_before_commit[:position]
+            raise 'rollitback_book'
+          end
+        end
+
+        belongs_to :department,
+          resource: DepartmentResource,
+          scope: -> { Department.all },
+          foreign_key: :department_id
+      end
+
+      class EmployeeResource < ApplicationResource
+        type :employees
+        model Employee
+
+        before_commit only: [:create] do |employee|
+          Callbacks.add(:create, employee)
+          if $raise_on_before_commit[:employee]
+            raise 'rollitback'
+          end
+        end
+
+        before_commit only: [:update] do |employee|
+          Callbacks.add(:update, employee)
+          if $raise_on_before_commit[:employee]
+            raise 'rollitback'
+          end
+        end
+
+        before_commit only: [:destroy] do |employee|
+          Callbacks.add(:destroy, employee)
+          if $raise_on_before_commit[:employee]
+            raise 'rollitback'
+          end
+        end
+
+        has_many :positions,
+          foreign_key: :employee_id,
+          scope: -> { Position.all },
+          resource: PositionResource
+      end
+    end
+
+    controller(ApplicationController) do
+      jsonapi resource: IntegrationHooks::EmployeeResource
+
+      def create
+        employee, success = jsonapi_create.to_a
+
+        if success
+          render_jsonapi(employee, scope: false)
+        else
+          raise 'whoops'
+        end
+      end
+
+      def update
+        employee, success = jsonapi_update.to_a
+
+        if success
+          render_jsonapi(employee, scope: false)
+        else
+          raise 'whoops'
+        end
+      end
+
+      def destroy
+        employee, success = jsonapi_destroy.to_a
+
+        if success
+          render_jsonapi(employee, scope: false)
+        else
+          raise 'whoops'
+        end
+      end
+
+      private
+
+      def params
+        @params ||= begin
+          hash = super.to_unsafe_h.with_indifferent_access
+          hash = hash[:params] if hash.has_key?(:params)
+          hash
+        end
+      end
+    end
+
+    before do
+      @request.headers['Accept'] = Mime[:json]
+      @request.headers['Content-Type'] = Mime[:json].to_s
+
+      routes.draw {
+        post "create" => "anonymous#create"
+        put "update" => "anonymous#update"
+        delete "destroy" => "anonymous#destroy"
+      }
+    end
+
+    def json
+      JSON.parse(response.body)
+    end
+
+    context 'before_commit' do
+      context 'on create' do
+        let(:payload) do
+          {
+            data: {
+              type: 'employees'
+            }
+          }
+        end
+
+        it 'fires after validations but before ending the transaction' do
+          expect_any_instance_of(JsonapiCompliable::Util::ValidationResponse)
+            .to receive(:validate!)
+          expect {
+            post :create, params: payload
+          }.to raise_error('rollitback')
+          expect(Employee.count).to be_zero
+          expect(Callbacks.entities.length).to eq(1)
+          expect(Callbacks.fired[:create]).to be_a(Employee)
+        end
+      end
+
+      context 'nested' do
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              attributes: { first_name: 'joe' },
+              relationships: {
+                positions: {
+                  data: [
+                    { :'temp-id' => 'a', type: 'positions', method: 'create' }
+                  ]
+                }
+              }
+            },
+            included: [
+              {
+                type: 'positions',
+                :'temp-id' => 'a',
+                relationships: {
+                  department: {
+                    data: {
+                      :'temp-id' => 'b', type: 'departments', method: 'create'
+                    }
+                  }
+                }
+              },
+              {
+                type: 'departments',
+                :'temp-id' => 'b'
+              }
+            ]
+          }
+        end
+
+        before do
+          $raise_on_before_commit = {}
+        end
+
+        it 'fires after validations but before ending the transaction' do
+          expect_any_instance_of(JsonapiCompliable::Util::ValidationResponse)
+            .to receive(:validate!)
+          post :create, params: payload
+          expect(Callbacks.entities)
+            .to eq([:create, :position, :department])
+          expect(Callbacks.fired[:create]).to be_a(Employee)
+          expect(Callbacks.fired[:position]).to be_a(Position)
+          expect(Callbacks.fired[:department]).to be_a(Department)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These hooks run after validating the whole graph, but before closing the
transaction. Helpful for things like "contact this service after saving,
but rollback if the service is down".

Moves the existing sideload hooks to the same place (the previous
behavior was to fire before validations).

Implemented by a Hook accumulator that uses Thread.current. I've tried
this a few different ways but recursive functions that return a mash of
objects seem to add a lot of complexity to the code for no real reason.
The premise of registering hooks during a complex process, then calling
those hooks later, is simpler.

This does add a small amount of duplication between the create/update
actions and the destroy action. This is because we're currently not
supporting DELETE requests with a body (nested deletes) so the
processing logic is different. Think this can be assimliated in a
separate PR.

*suggest viewing the first 