### PR TITLE
allowing for extension of Scoping::Filter class

### DIFF
--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -93,11 +93,13 @@ module JsonapiCompliable
 
     def apply_scoping(opts)
       @object = JsonapiCompliable::Scoping::DefaultFilter.new(@resource, query_hash, @object).apply
-      @object = JsonapiCompliable::Scoping::Filter.new(@resource, query_hash, @object).apply unless opts[:filter] == false
+      @object = filter_class.new(@resource, query_hash, @object).apply unless opts[:filter] == false
       @object = JsonapiCompliable::Scoping::ExtraFields.new(@resource, query_hash, @object).apply unless opts[:extra_fields] == false
       @object = JsonapiCompliable::Scoping::Sort.new(@resource, query_hash, @object).apply unless opts[:sort] == false
       @unpaginated_object = @object
       @object = JsonapiCompliable::Scoping::Paginate.new(@resource, query_hash, @object, default: opts[:default_paginate]).apply unless opts[:paginate] == false
     end
+
+    def filter_class; ::JsonapiCompliable::Scoping::Filter; end
   end
 end

--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -91,15 +91,17 @@ module JsonapiCompliable
       end
     end
 
-    def apply_scoping(opts)
-      @object = JsonapiCompliable::Scoping::DefaultFilter.new(@resource, query_hash, @object).apply
-      @object = filter_class.new(@resource, query_hash, @object).apply unless opts[:filter] == false
-      @object = JsonapiCompliable::Scoping::ExtraFields.new(@resource, query_hash, @object).apply unless opts[:extra_fields] == false
-      @object = JsonapiCompliable::Scoping::Sort.new(@resource, query_hash, @object).apply unless opts[:sort] == false
-      @unpaginated_object = @object
-      @object = JsonapiCompliable::Scoping::Paginate.new(@resource, query_hash, @object, default: opts[:default_paginate]).apply unless opts[:paginate] == false
+     def apply_scoping(opts)
+      add_scoping(nil, JsonapiCompliable::Scoping::DefaultFilter, opts)
+      add_scoping(:filter, JsonapiCompliable::Scoping::Filter, opts)
+      add_scoping(:extra_fields, JsonapiCompliable::Scoping::ExtraFields, opts)
+      add_scoping(:sort, JsonapiCompliable::Scoping::Sort, opts)
+      add_scoping(:paginate, JsonapiCompliable::Scoping::Paginate, opts, default: opts[:default_paginate])
     end
 
-    def filter_class; ::JsonapiCompliable::Scoping::Filter; end
+    def add_scoping(key, scoping_class, opts, default = {})
+      @object = scoping_class.new(@resource, query_hash, @object, default).apply unless opts[key] == false
+      @unpaginated_object = @object unless key == :paginate
+    end
   end
 end


### PR DESCRIPTION
This change will allow someone to extend filtering classes like `sonapiCompliable::Scoping::DefaultFilter`, `JsonapiCompliable::Scoping::Filter`, `JsonapiCompliable::Scoping::Sort`, etc. for any additional or modified functionality.