### PR TITLE
Make raising on missing sideload configurable

### DIFF
--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -1,4 +1,5 @@
 require "jsonapi_compliable/version"
+require "jsonapi_compliable/configuration"
 require "jsonapi_compliable/errors"
 require "jsonapi_compliable/resource"
 require "jsonapi_compliable/query"
@@ -63,5 +64,19 @@ module JsonapiCompliable
     ensure
       self.context = prior
     end
+  end
+
+  def self.config
+    @config ||= Configuration.new
+  end
+
+  # @example
+  #   JsonapiCompliable.configure do |c|
+  #     c.raise_on_missing_sideload = false
+  #   end
+  #
+  # @see Configuration
+  def self.configure
+    yield config
   end
 end

--- a/lib/jsonapi_compliable/configuration.rb
+++ b/lib/jsonapi_compliable/configuration.rb
@@ -1,0 +1,14 @@
+# https://robots.thoughtbot.com/mygem-configure-block
+module JsonapiCompliable
+  class Configuration
+    # @return [Boolean] Should we raise when the client requests a relationship not defined on the server?
+    #   Defaults to true.
+    attr_accessor :raise_on_missing_sideload
+
+    # Set defaults
+    # @api private
+    def initialize
+      @raise_on_missing_sideload = true
+    end
+  end
+end

--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -82,12 +82,15 @@ module JsonapiCompliable
       includes.each_pair do |name, nested|
         sideload = @resource.sideload(name)
 
-        unless sideload
-          raise JsonapiCompliable::Errors::InvalidInclude.new(name, @resource.type)
+        if sideload.nil?
+          if JsonapiCompliable.config.raise_on_missing_sideload
+            raise JsonapiCompliable::Errors::InvalidInclude
+              .new(name, @resource.type)
+          end
+        else
+          namespace = Util::Sideload.namespace(@namespace, sideload.name)
+          sideload.resolve(results, @query, namespace)
         end
-
-        namespace = Util::Sideload.namespace(@namespace, sideload.name)
-        sideload.resolve(results, @query, namespace)
       end
     end
 

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -70,9 +70,22 @@ RSpec.describe JsonapiCompliable::Scope do
         end
 
         it 'raises a helpful error' do
-          expect do
+          expect {
             instance.resolve
-          end.to raise_error(JsonapiCompliable::Errors::InvalidInclude, 'The requested included relationship "books" is not supported on resource "authors"')
+          }.to raise_error(JsonapiCompliable::Errors::InvalidInclude, 'The requested included relationship "books" is not supported on resource "authors"')
+        end
+
+        context 'but the config says not to raise errors' do
+          before do
+            allow(JsonapiCompliable.config)
+              .to receive(:raise_on_missing_sideload)
+          end
+
+          it 'does not raise an error' do
+            expect {
+              instance.resolve
+            }.to_not raise_error
+          end
         end
       end
     end


### PR DESCRIPTION
It can be desirable to silently drop the relationship instead of
raising an error. This is now configurable:

```ruby
JsonapiCompliable.configure do |c|
  c.raise_on_missing_sideload = false
end
```