### PR TITLE
Expose #object and #unpaginated_object on scope

### DIFF
--- a/docs/Jsonapi.html
+++ b/docs/Jsonapi.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/Jsonapi/ResourceGenerator.html
+++ b/docs/Jsonapi/ResourceGenerator.html
@@ -215,7 +215,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable.html
+++ b/docs/JsonapiCompliable.html
@@ -554,7 +554,7 @@ href="https://robots.thoughtbot.com/mygem-configure-block">robots.thoughtbot.com
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Adapters.html
+++ b/docs/JsonapiCompliable/Adapters.html
@@ -109,7 +109,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Adapters/Abstract.html
+++ b/docs/JsonapiCompliable/Adapters/Abstract.html
@@ -2451,7 +2451,7 @@ This method should roll back the transaction if an error is raised.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Adapters/ActiveRecord.html
+++ b/docs/JsonapiCompliable/Adapters/ActiveRecord.html
@@ -2243,7 +2243,7 @@ Sideload#allow_sideload</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Adapters/ActiveRecordSideloading.html
+++ b/docs/JsonapiCompliable/Adapters/ActiveRecordSideloading.html
@@ -580,7 +580,7 @@ end</pre>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Adapters/Null.html
+++ b/docs/JsonapiCompliable/Adapters/Null.html
@@ -1672,7 +1672,7 @@ an HTTP call, etc.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Base.html
+++ b/docs/JsonapiCompliable/Base.html
@@ -1764,7 +1764,7 @@ Helpful for easy-access to things like the current user.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Configuration.html
+++ b/docs/JsonapiCompliable/Configuration.html
@@ -298,7 +298,7 @@ server? Defaults to true.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Deserializer.html
+++ b/docs/JsonapiCompliable/Deserializer.html
@@ -892,7 +892,7 @@ create/update/destroy/disassociate. Based on the request env or the
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors.html
+++ b/docs/JsonapiCompliable/Errors.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/BadFilter.html
+++ b/docs/JsonapiCompliable/Errors/BadFilter.html
@@ -114,7 +114,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/InvalidInclude.html
+++ b/docs/JsonapiCompliable/Errors/InvalidInclude.html
@@ -256,7 +256,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/RecordNotFound.html
+++ b/docs/JsonapiCompliable/Errors/RecordNotFound.html
@@ -114,7 +114,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/StatNotFound.html
+++ b/docs/JsonapiCompliable/Errors/StatNotFound.html
@@ -256,7 +256,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/UnsupportedPageSize.html
+++ b/docs/JsonapiCompliable/Errors/UnsupportedPageSize.html
@@ -254,7 +254,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Errors/ValidationError.html
+++ b/docs/JsonapiCompliable/Errors/ValidationError.html
@@ -114,7 +114,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Extensions.html
+++ b/docs/JsonapiCompliable/Extensions.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Extensions/BooleanAttribute.html
+++ b/docs/JsonapiCompliable/Extensions/BooleanAttribute.html
@@ -202,7 +202,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Extensions/BooleanAttribute/ClassMethods.html
+++ b/docs/JsonapiCompliable/Extensions/BooleanAttribute/ClassMethods.html
@@ -219,7 +219,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Extensions/ExtraAttribute.html
+++ b/docs/JsonapiCompliable/Extensions/ExtraAttribute.html
@@ -232,7 +232,7 @@ extra attribute. See (Resource.extra_field).</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Extensions/ExtraAttribute/ClassMethods.html
+++ b/docs/JsonapiCompliable/Extensions/ExtraAttribute/ClassMethods.html
@@ -227,7 +227,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Query.html
+++ b/docs/JsonapiCompliable/Query.html
@@ -1097,7 +1097,7 @@ get, say, the total count without the overhead of fetching actual records.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Rails.html
+++ b/docs/JsonapiCompliable/Rails.html
@@ -201,7 +201,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Resource.html
+++ b/docs/JsonapiCompliable/Resource.html
@@ -5091,7 +5091,7 @@ Rails controller context</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scope.html
+++ b/docs/JsonapiCompliable/Scope.html
@@ -136,6 +136,69 @@ scope.</p>
 
 
 
+  <h2>Instance Attribute Summary <small><a href="#" class="summary_toggle">collapse</a></small></h2>
+  <ul class="summary">
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#object-instance_method" title="#object (instance method)">#<strong>object</strong>  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+    
+      <span class="note title readonly">readonly</span>
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Returns the value of attribute object.</p>
+</div></span>
+  
+</li>
+
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#unpaginated_object-instance_method" title="#unpaginated_object (instance method)">#<strong>unpaginated_object</strong>  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+    
+      <span class="note title readonly">readonly</span>
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Returns the value of attribute unpaginated_object.</p>
+</div></span>
+  
+</li>
+
+    
+  </ul>
+
 
 
 
@@ -443,8 +506,6 @@ scope.</p>
       <pre class="lines">
 
 
-27
-28
 29
 30
 31
@@ -455,10 +516,12 @@ scope.</p>
 36
 37
 38
-39</pre>
+39
+40
+41</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 27</span>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 29</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_object'>object</span><span class='comma'>,</span> <span class='id identifier rubyid_resource'>resource</span><span class='comma'>,</span> <span class='id identifier rubyid_query'>query</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='ivar'>@object</span>    <span class='op'>=</span> <span class='id identifier rubyid_object'>object</span>
@@ -479,6 +542,97 @@ scope.</p>
 </div>
   
 </div>
+
+  <div id="instance_attr_details" class="attr_details">
+    <h2>Instance Attribute Details</h2>
+    
+      
+      <span id=""></span>
+      <div class="method_details first">
+  <h3 class="signature first" id="object-instance_method">
+  
+    #<strong>object</strong>  &#x21d2; <tt>Object</tt>  <span class="extras">(readonly)</span>
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns the value of attribute object</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+17
+18
+19</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 17</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_object'>object</span>
+  <span class='ivar'>@object</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      
+      <span id=""></span>
+      <div class="method_details ">
+  <h3 class="signature " id="unpaginated_object-instance_method">
+  
+    #<strong>unpaginated_object</strong>  &#x21d2; <tt>Object</tt>  <span class="extras">(readonly)</span>
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns the value of attribute unpaginated_object</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+17
+18
+19</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 17</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_unpaginated_object'>unpaginated_object</span>
+  <span class='ivar'>@unpaginated_object</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+  </div>
 
 
   <div id="instance_method_details" class="method_details_list">
@@ -522,12 +676,12 @@ scope.</p>
       <pre class="lines">
 
 
-73
-74
-75</pre>
+75
+76
+77</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 73</span>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 75</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_query_hash'>query_hash</span>
   <span class='ivar'>@query_hash</span> <span class='op'>||=</span> <span class='ivar'>@query</span><span class='period'>.</span><span class='id identifier rubyid_to_hash'>to_hash</span><span class='lbracket'>[</span><span class='ivar'>@namespace</span><span class='rbracket'>]</span>
@@ -595,18 +749,18 @@ sideload</p>
       <pre class="lines">
 
 
-60
-61
 62
 63
 64
 65
 66
 67
-68</pre>
+68
+69
+70</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 60</span>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 62</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_resolve'>resolve</span>
   <span class='kw'>if</span> <span class='ivar'>@query</span><span class='period'>.</span><span class='id identifier rubyid_zero_results?'>zero_results?</span>
@@ -673,12 +827,12 @@ sideload</p>
       <pre class="lines">
 
 
-47
-48
-49</pre>
+49
+50
+51</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 47</span>
+      <pre class="code"><span class="info file"># File 'lib/jsonapi_compliable/scope.rb', line 49</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_resolve_stats'>resolve_stats</span>
   <span class='const'><span class='object_link'><a href="Stats.html" title="JsonapiCompliable::Stats (module)">Stats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Stats/Payload.html" title="JsonapiCompliable::Stats::Payload (class)">Payload</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Stats/Payload.html#initialize-instance_method" title="JsonapiCompliable::Stats::Payload#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='ivar'>@resource</span><span class='comma'>,</span> <span class='id identifier rubyid_query_hash'>query_hash</span><span class='comma'>,</span> <span class='ivar'>@unpaginated_object</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_generate'><span class='object_link'><a href="Stats/Payload.html#generate-instance_method" title="JsonapiCompliable::Stats::Payload#generate (method)">generate</a></span></span>
@@ -693,7 +847,7 @@ sideload</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping.html
+++ b/docs/JsonapiCompliable/Scoping.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/Base.html
+++ b/docs/JsonapiCompliable/Scoping/Base.html
@@ -833,7 +833,7 @@ a default in certain contexts.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/DefaultFilter.html
+++ b/docs/JsonapiCompliable/Scoping/DefaultFilter.html
@@ -308,7 +308,7 @@ filter, and apply the default proc unless an explicit override is requested</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/ExtraFields.html
+++ b/docs/JsonapiCompliable/Scoping/ExtraFields.html
@@ -291,7 +291,7 @@ for that field, run it. Otherwise, do nothing.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/Filter.html
+++ b/docs/JsonapiCompliable/Scoping/Filter.html
@@ -303,7 +303,7 @@ aliases. If valid, call either the default or custom filtering logic.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/Filterable.html
+++ b/docs/JsonapiCompliable/Scoping/Filterable.html
@@ -354,7 +354,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/Paginate.html
+++ b/docs/JsonapiCompliable/Scoping/Paginate.html
@@ -603,7 +603,7 @@ explicitly specified in the request.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Scoping/Sort.html
+++ b/docs/JsonapiCompliable/Scoping/Sort.html
@@ -446,7 +446,7 @@ proc:</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/SerializableTempId.html
+++ b/docs/JsonapiCompliable/SerializableTempId.html
@@ -206,7 +206,7 @@ reference it directly.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Sideload.html
+++ b/docs/JsonapiCompliable/Sideload.html
@@ -2968,7 +2968,7 @@ in your resource directly.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Stats.html
+++ b/docs/JsonapiCompliable/Stats.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Stats/DSL.html
+++ b/docs/JsonapiCompliable/Stats/DSL.html
@@ -989,7 +989,7 @@ configured.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Stats/Payload.html
+++ b/docs/JsonapiCompliable/Stats/Payload.html
@@ -381,7 +381,7 @@ results.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util.html
+++ b/docs/JsonapiCompliable/Util.html
@@ -107,7 +107,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:12 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/FieldParams.html
+++ b/docs/JsonapiCompliable/Util/FieldParams.html
@@ -218,7 +218,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/Hash.html
+++ b/docs/JsonapiCompliable/Util/Hash.html
@@ -461,7 +461,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/IncludeParams.html
+++ b/docs/JsonapiCompliable/Util/IncludeParams.html
@@ -289,7 +289,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/Persistence.html
+++ b/docs/JsonapiCompliable/Util/Persistence.html
@@ -435,7 +435,7 @@ know the primary key value of the parent before persisting the child.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/RelationshipPayload.html
+++ b/docs/JsonapiCompliable/Util/RelationshipPayload.html
@@ -553,7 +553,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:14 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/RenderOptions.html
+++ b/docs/JsonapiCompliable/Util/RenderOptions.html
@@ -254,7 +254,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/Sideload.html
+++ b/docs/JsonapiCompliable/Util/Sideload.html
@@ -234,7 +234,7 @@ second will be “children.children” and so forth.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:13 2018 by
+  Generated on Thu May  3 15:52:18 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/JsonapiCompliable/Util/ValidationResponse.html
+++ b/docs/JsonapiCompliable/Util/ValidationResponse.html
@@ -522,7 +522,7 @@ errors.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:14 2018 by
+  Generated on Thu May  3 15:52:19 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -557,7 +557,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:11 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -128,7 +128,7 @@ $ yard server
 </div></div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:11 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,7 +128,7 @@ $ yard server
 </div></div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:11 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -78,16 +78,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#allow_sideload-class_method" title="JsonapiCompliable::Resource.allow_sideload (method)">allow_sideload</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#allow_sideload-instance_method" title="JsonapiCompliable::Sideload#allow_sideload (method)">#allow_sideload</a></span>
+      <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#allow_sideload-instance_method" title="JsonapiCompliable::Sideload#allow_sideload (method)">#allow_sideload</a></span>
-      <small>JsonapiCompliable::Sideload</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#allow_sideload-class_method" title="JsonapiCompliable::Resource.allow_sideload (method)">allow_sideload</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -102,8 +102,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Filter.html#apply-instance_method" title="JsonapiCompliable::Scoping::Filter#apply (method)">#apply</a></span>
-      <small>JsonapiCompliable::Scoping::Filter</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Paginate.html#apply-instance_method" title="JsonapiCompliable::Scoping::Paginate#apply (method)">#apply</a></span>
+      <small>JsonapiCompliable::Scoping::Paginate</small>
     </div>
   </li>
   
@@ -118,24 +118,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/ExtraFields.html#apply-instance_method" title="JsonapiCompliable::Scoping::ExtraFields#apply (method)">#apply</a></span>
-      <small>JsonapiCompliable::Scoping::ExtraFields</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Scoping/DefaultFilter.html#apply-instance_method" title="JsonapiCompliable::Scoping::DefaultFilter#apply (method)">#apply</a></span>
       <small>JsonapiCompliable::Scoping::DefaultFilter</small>
     </div>
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/ExtraFields.html#apply-instance_method" title="JsonapiCompliable::Scoping::ExtraFields#apply (method)">#apply</a></span>
+      <small>JsonapiCompliable::Scoping::ExtraFields</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Paginate.html#apply-instance_method" title="JsonapiCompliable::Scoping::Paginate#apply (method)">#apply</a></span>
-      <small>JsonapiCompliable::Scoping::Paginate</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Filter.html#apply-instance_method" title="JsonapiCompliable::Scoping::Filter#apply (method)">#apply</a></span>
+      <small>JsonapiCompliable::Scoping::Filter</small>
     </div>
   </li>
   
@@ -166,7 +166,23 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Sort.html#apply_custom_scope-instance_method" title="JsonapiCompliable::Scoping::Sort#apply_custom_scope (method)">#apply_custom_scope</a></span>
+      <small>JsonapiCompliable::Scoping::Sort</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#apply_custom_scope-instance_method" title="JsonapiCompliable::Scoping::Base#apply_custom_scope (method)">#apply_custom_scope</a></span>
+      <small>JsonapiCompliable::Scoping::Base</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#apply_standard_scope-instance_method" title="JsonapiCompliable::Scoping::Base#apply_standard_scope (method)">#apply_standard_scope</a></span>
       <small>JsonapiCompliable::Scoping::Base</small>
     </div>
   </li>
@@ -174,8 +190,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Sort.html#apply_custom_scope-instance_method" title="JsonapiCompliable::Scoping::Sort#apply_custom_scope (method)">#apply_custom_scope</a></span>
-      <small>JsonapiCompliable::Scoping::Sort</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Paginate.html#apply_standard_scope-instance_method" title="JsonapiCompliable::Scoping::Paginate#apply_standard_scope (method)">#apply_standard_scope</a></span>
+      <small>JsonapiCompliable::Scoping::Paginate</small>
     </div>
   </li>
   
@@ -184,22 +200,6 @@
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Scoping/Sort.html#apply_standard_scope-instance_method" title="JsonapiCompliable::Scoping::Sort#apply_standard_scope (method)">#apply_standard_scope</a></span>
       <small>JsonapiCompliable::Scoping::Sort</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#apply_standard_scope-instance_method" title="JsonapiCompliable::Scoping::Base#apply_standard_scope (method)">#apply_standard_scope</a></span>
-      <small>JsonapiCompliable::Scoping::Base</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Paginate.html#apply_standard_scope-instance_method" title="JsonapiCompliable::Scoping::Paginate#apply_standard_scope (method)">#apply_standard_scope</a></span>
-      <small>JsonapiCompliable::Scoping::Paginate</small>
     </div>
   </li>
   
@@ -230,16 +230,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#associate-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#associate (method)">#associate</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#associate-instance_method" title="JsonapiCompliable::Resource#associate (method)">#associate</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#associate-instance_method" title="JsonapiCompliable::Resource#associate (method)">#associate</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#associate-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#associate (method)">#associate</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
@@ -254,32 +254,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#associate-instance_method" title="JsonapiCompliable::Adapters::Abstract#associate (method)">#associate</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#associate-instance_method" title="JsonapiCompliable::Adapters::Null#associate (method)">#associate</a></span>
       <small>JsonapiCompliable::Adapters::Null</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#association_names-instance_method" title="JsonapiCompliable::Resource#association_names (method)">#association_names</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#association_names-instance_method" title="JsonapiCompliable::Sideload#association_names (method)">#association_names</a></span>
-      <small>JsonapiCompliable::Sideload</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#associate-instance_method" title="JsonapiCompliable::Adapters::Abstract#associate (method)">#associate</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
@@ -288,6 +272,22 @@
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Query.html#association_names-instance_method" title="JsonapiCompliable::Query#association_names (method)">#association_names</a></span>
       <small>JsonapiCompliable::Query</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#association_names-instance_method" title="JsonapiCompliable::Resource#association_names (method)">#association_names</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#association_names-instance_method" title="JsonapiCompliable::Sideload#association_names (method)">#association_names</a></span>
+      <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
@@ -310,8 +310,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#average-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#average (method)">#average</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#average-instance_method" title="JsonapiCompliable::Adapters::Abstract#average (method)">#average</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
@@ -326,8 +326,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#average-instance_method" title="JsonapiCompliable::Adapters::Abstract#average (method)">#average</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#average-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#average (method)">#average</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
@@ -342,16 +342,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#belongs_to-class_method" title="JsonapiCompliable::Resource.belongs_to (method)">belongs_to</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#belongs_to-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#belongs_to (method)">#belongs_to</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#belongs_to-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#belongs_to (method)">#belongs_to</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#belongs_to-class_method" title="JsonapiCompliable::Resource.belongs_to (method)">belongs_to</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -390,16 +390,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable.html#config-class_method" title="JsonapiCompliable.config (method)">config</a></span>
-      <small>JsonapiCompliable</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#config-class_method" title="JsonapiCompliable::Resource.config (method)">config</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#config-class_method" title="JsonapiCompliable::Resource.config (method)">config</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable.html#config-class_method" title="JsonapiCompliable.config (method)">config</a></span>
+      <small>JsonapiCompliable</small>
     </div>
   </li>
   
@@ -414,16 +414,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable.html#context-class_method" title="JsonapiCompliable.context (method)">context</a></span>
-      <small>JsonapiCompliable</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#context-instance_method" title="JsonapiCompliable::Resource#context (method)">#context</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#context-instance_method" title="JsonapiCompliable::Resource#context (method)">#context</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable.html#context-class_method" title="JsonapiCompliable.context (method)">context</a></span>
+      <small>JsonapiCompliable</small>
     </div>
   </li>
   
@@ -454,24 +454,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#count-instance_method" title="JsonapiCompliable::Adapters::Abstract#count (method)">#count</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#count-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#count (method)">#count</a></span>
       <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#count-instance_method" title="JsonapiCompliable::Adapters::Null#count (method)">#count</a></span>
       <small>JsonapiCompliable::Adapters::Null</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#count-instance_method" title="JsonapiCompliable::Adapters::Abstract#count (method)">#count</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
@@ -486,16 +486,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#create-instance_method" title="JsonapiCompliable::Adapters::Abstract#create (method)">#create</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#create-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#create (method)">#create</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#create-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#create (method)">#create</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#create-instance_method" title="JsonapiCompliable::Adapters::Abstract#create (method)">#create</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
@@ -662,24 +662,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#disassociate-instance_method" title="JsonapiCompliable::Sideload#disassociate (method)">#disassociate</a></span>
-      <small>JsonapiCompliable::Sideload</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#disassociate-instance_method" title="JsonapiCompliable::Adapters::Abstract#disassociate (method)">#disassociate</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#disassociate-instance_method" title="JsonapiCompliable::Resource#disassociate (method)">#disassociate</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#disassociate-instance_method" title="JsonapiCompliable::Sideload#disassociate (method)">#disassociate</a></span>
+      <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#disassociate-instance_method" title="JsonapiCompliable::Adapters::Abstract#disassociate (method)">#disassociate</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#disassociate-instance_method" title="JsonapiCompliable::Resource#disassociate (method)">#disassociate</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -718,8 +718,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#filter-instance_method" title="JsonapiCompliable::Adapters::Null#filter (method)">#filter</a></span>
-      <small>JsonapiCompliable::Adapters::Null</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#filter-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#filter (method)">#filter</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
@@ -734,8 +734,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#filter-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#filter (method)">#filter</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#filter-instance_method" title="JsonapiCompliable::Adapters::Null#filter (method)">#filter</a></span>
+      <small>JsonapiCompliable::Adapters::Null</small>
     </div>
   </li>
   
@@ -822,29 +822,21 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#has_and_belongs_to_many-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#has_and_belongs_to_many (method)">#has_and_belongs_to_many</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Resource.html#has_and_belongs_to_many-class_method" title="JsonapiCompliable::Resource.has_and_belongs_to_many (method)">has_and_belongs_to_many</a></span>
       <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#has_many-class_method" title="JsonapiCompliable::Resource.has_many (method)">has_many</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#has_and_belongs_to_many-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#has_and_belongs_to_many (method)">#has_and_belongs_to_many</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#has_many-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#has_many (method)">#has_many</a></span>
       <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
@@ -852,18 +844,26 @@
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#has_many-class_method" title="JsonapiCompliable::Resource.has_many (method)">has_many</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#has_one-class_method" title="JsonapiCompliable::Resource.has_one (method)">has_one</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#has_one-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#has_one (method)">#has_one</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#has_one-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#has_one (method)">#has_one</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#has_one-class_method" title="JsonapiCompliable::Resource.has_one (method)">has_one</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -910,8 +910,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Extensions/ExtraAttribute.html#included-class_method" title="JsonapiCompliable::Extensions::ExtraAttribute.included (method)">included</a></span>
-      <small>JsonapiCompliable::Extensions::ExtraAttribute</small>
+      <span class='object_link'><a href="JsonapiCompliable.html#included-class_method" title="JsonapiCompliable.included (method)">included</a></span>
+      <small>JsonapiCompliable</small>
     </div>
   </li>
   
@@ -926,16 +926,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Extensions/BooleanAttribute.html#included-class_method" title="JsonapiCompliable::Extensions::BooleanAttribute.included (method)">included</a></span>
-      <small>JsonapiCompliable::Extensions::BooleanAttribute</small>
+      <span class='object_link'><a href="JsonapiCompliable/Extensions/ExtraAttribute.html#included-class_method" title="JsonapiCompliable::Extensions::ExtraAttribute.included (method)">included</a></span>
+      <small>JsonapiCompliable::Extensions::ExtraAttribute</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable.html#included-class_method" title="JsonapiCompliable.included (method)">included</a></span>
-      <small>JsonapiCompliable</small>
+      <span class='object_link'><a href="JsonapiCompliable/Extensions/BooleanAttribute.html#included-class_method" title="JsonapiCompliable::Extensions::BooleanAttribute.included (method)">included</a></span>
+      <small>JsonapiCompliable::Extensions::BooleanAttribute</small>
     </div>
   </li>
   
@@ -958,70 +958,6 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#initialize-instance_method" title="JsonapiCompliable::Sideload#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Sideload</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#initialize-instance_method" title="JsonapiCompliable::Util::RelationshipPayload#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Util::RelationshipPayload</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#initialize-instance_method" title="JsonapiCompliable::Scoping::Base#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Scoping::Base</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Stats/DSL.html#initialize-instance_method" title="JsonapiCompliable::Stats::DSL#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Stats::DSL</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Configuration.html#initialize-instance_method" title="JsonapiCompliable::Configuration#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Configuration</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/Persistence.html#initialize-instance_method" title="JsonapiCompliable::Util::Persistence#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Util::Persistence</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Errors/UnsupportedPageSize.html#initialize-instance_method" title="JsonapiCompliable::Errors::UnsupportedPageSize#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Errors::UnsupportedPageSize</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Errors/InvalidInclude.html#initialize-instance_method" title="JsonapiCompliable::Errors::InvalidInclude#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Errors::InvalidInclude</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Errors/StatNotFound.html#initialize-instance_method" title="JsonapiCompliable::Errors::StatNotFound#initialize (method)">#initialize</a></span>
       <small>JsonapiCompliable::Errors::StatNotFound</small>
     </div>
@@ -1038,6 +974,22 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#initialize-instance_method" title="JsonapiCompliable::Util::RelationshipPayload#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Util::RelationshipPayload</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Util/Persistence.html#initialize-instance_method" title="JsonapiCompliable::Util::Persistence#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Util::Persistence</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Util/ValidationResponse.html#initialize-instance_method" title="JsonapiCompliable::Util::ValidationResponse#initialize (method)">#initialize</a></span>
       <small>JsonapiCompliable::Util::ValidationResponse</small>
     </div>
@@ -1046,8 +998,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Deserializer.html#initialize-instance_method" title="JsonapiCompliable::Deserializer#initialize (method)">#initialize</a></span>
-      <small>JsonapiCompliable::Deserializer</small>
+      <span class='object_link'><a href="JsonapiCompliable/Stats/DSL.html#initialize-instance_method" title="JsonapiCompliable::Stats::DSL#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Stats::DSL</small>
     </div>
   </li>
   
@@ -1062,7 +1014,55 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#iterate-instance_method" title="JsonapiCompliable::Util::RelationshipPayload#iterate (method)">#iterate</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Configuration.html#initialize-instance_method" title="JsonapiCompliable::Configuration#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Deserializer.html#initialize-instance_method" title="JsonapiCompliable::Deserializer#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Deserializer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Errors/UnsupportedPageSize.html#initialize-instance_method" title="JsonapiCompliable::Errors::UnsupportedPageSize#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Errors::UnsupportedPageSize</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#initialize-instance_method" title="JsonapiCompliable::Sideload#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Sideload</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Errors/InvalidInclude.html#initialize-instance_method" title="JsonapiCompliable::Errors::InvalidInclude#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Errors::InvalidInclude</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#initialize-instance_method" title="JsonapiCompliable::Scoping::Base#initialize (method)">#initialize</a></span>
+      <small>JsonapiCompliable::Scoping::Base</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#iterate-class_method" title="JsonapiCompliable::Util::RelationshipPayload.iterate (method)">iterate</a></span>
       <small>JsonapiCompliable::Util::RelationshipPayload</small>
     </div>
   </li>
@@ -1070,7 +1070,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#iterate-class_method" title="JsonapiCompliable::Util::RelationshipPayload.iterate (method)">iterate</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#iterate-instance_method" title="JsonapiCompliable::Util::RelationshipPayload#iterate (method)">#iterate</a></span>
       <small>JsonapiCompliable::Util::RelationshipPayload</small>
     </div>
   </li>
@@ -1206,16 +1206,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#minimum-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#minimum (method)">#minimum</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#minimum-instance_method" title="JsonapiCompliable::Adapters::Abstract#minimum (method)">#minimum</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#minimum-instance_method" title="JsonapiCompliable::Adapters::Abstract#minimum (method)">#minimum</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#minimum-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#minimum (method)">#minimum</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
@@ -1238,7 +1238,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#model-instance_method" title="JsonapiCompliable::Resource#model (method)">#model</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#model-class_method" title="JsonapiCompliable::Resource.model (method)">model</a></span>
       <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
@@ -1246,7 +1246,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#model-class_method" title="JsonapiCompliable::Resource.model (method)">model</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#model-instance_method" title="JsonapiCompliable::Resource#model (method)">#model</a></span>
       <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
@@ -1286,21 +1286,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#order-instance_method" title="JsonapiCompliable::Adapters::Abstract#order (method)">#order</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scope.html#object-instance_method" title="JsonapiCompliable::Scope#object (method)">#object</a></span>
+      <small>JsonapiCompliable::Scope</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#order-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#order (method)">#order</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#order-instance_method" title="JsonapiCompliable::Adapters::Null#order (method)">#order</a></span>
       <small>JsonapiCompliable::Adapters::Null</small>
@@ -1308,17 +1300,9 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#paginate-class_method" title="JsonapiCompliable::Resource.paginate (method)">paginate</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#paginate-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#paginate (method)">#paginate</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#order-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#order (method)">#order</a></span>
       <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
@@ -1326,8 +1310,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#paginate-instance_method" title="JsonapiCompliable::Adapters::Null#paginate (method)">#paginate</a></span>
-      <small>JsonapiCompliable::Adapters::Null</small>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#order-instance_method" title="JsonapiCompliable::Adapters::Abstract#order (method)">#order</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#paginate-class_method" title="JsonapiCompliable::Resource.paginate (method)">paginate</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#paginate-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#paginate (method)">#paginate</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
     </div>
   </li>
   
@@ -1342,13 +1342,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#paginate-instance_method" title="JsonapiCompliable::Adapters::Null#paginate (method)">#paginate</a></span>
+      <small>JsonapiCompliable::Adapters::Null</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Resource.html#pagination-instance_method" title="JsonapiCompliable::Resource#pagination (method)">#pagination</a></span>
       <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Query.html#params-instance_method" title="JsonapiCompliable::Query#params (method)">#params</a></span>
       <small>JsonapiCompliable::Query</small>
@@ -1356,7 +1364,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#parent-instance_method" title="JsonapiCompliable::Sideload#parent (method)">#parent</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1364,7 +1372,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Util/FieldParams.html#parse-class_method" title="JsonapiCompliable::Util::FieldParams.parse (method)">parse</a></span>
       <small>JsonapiCompliable::Util::FieldParams</small>
@@ -1372,7 +1380,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Util/RelationshipPayload.html#payload-instance_method" title="JsonapiCompliable::Util::RelationshipPayload#payload (method)">#payload</a></span>
       <small>JsonapiCompliable::Util::RelationshipPayload</small>
@@ -1380,7 +1388,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Resource.html#persist_with_relationships-instance_method" title="JsonapiCompliable::Resource#persist_with_relationships (method)">#persist_with_relationships</a></span>
       <small>JsonapiCompliable::Resource</small>
@@ -1388,7 +1396,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#polymorphic-instance_method" title="JsonapiCompliable::Sideload#polymorphic (method)">#polymorphic</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1396,18 +1404,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#polymorphic%3F-instance_method" title="JsonapiCompliable::Sideload#polymorphic? (method)">#polymorphic?</a></span>
       <small>JsonapiCompliable::Sideload</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#polymorphic_belongs_to-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#polymorphic_belongs_to (method)">#polymorphic_belongs_to</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
     </div>
   </li>
   
@@ -1422,13 +1422,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecordSideloading.html#polymorphic_belongs_to-instance_method" title="JsonapiCompliable::Adapters::ActiveRecordSideloading#polymorphic_belongs_to (method)">#polymorphic_belongs_to</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecordSideloading</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#polymorphic_child_for_type-instance_method" title="JsonapiCompliable::Sideload#polymorphic_child_for_type (method)">#polymorphic_child_for_type</a></span>
       <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#polymorphic_groups-instance_method" title="JsonapiCompliable::Sideload#polymorphic_groups (method)">#polymorphic_groups</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1436,7 +1444,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Resource.html#polymorphic_has_many-class_method" title="JsonapiCompliable::Resource.polymorphic_has_many (method)">polymorphic_has_many</a></span>
       <small>JsonapiCompliable::Resource</small>
@@ -1444,7 +1452,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#primary_key-instance_method" title="JsonapiCompliable::Sideload#primary_key (method)">#primary_key</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1452,7 +1460,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Base.html#query-instance_method" title="JsonapiCompliable::Base#query (method)">#query</a></span>
       <small>JsonapiCompliable::Base</small>
@@ -1460,23 +1468,7 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#query_hash-instance_method" title="JsonapiCompliable::Scoping::Base#query_hash (method)">#query_hash</a></span>
-      <small>JsonapiCompliable::Scoping::Base</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scope.html#query_hash-instance_method" title="JsonapiCompliable::Scope#query_hash (method)">#query_hash</a></span>
-      <small>JsonapiCompliable::Scope</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Base.html#query_hash-instance_method" title="JsonapiCompliable::Base#query_hash (method)">#query_hash</a></span>
       <small>JsonapiCompliable::Base</small>
@@ -1484,33 +1476,9 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Configuration.html#raise_on_missing_sideload-instance_method" title="JsonapiCompliable::Configuration#raise_on_missing_sideload (method)">#raise_on_missing_sideload</a></span>
-      <small>JsonapiCompliable::Configuration</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Deserializer.html#relationships-instance_method" title="JsonapiCompliable::Deserializer#relationships (method)">#relationships</a></span>
-      <small>JsonapiCompliable::Deserializer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Base.html#render_jsonapi-instance_method" title="JsonapiCompliable::Base#render_jsonapi (method)">#render_jsonapi</a></span>
-      <small>JsonapiCompliable::Base</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scope.html#resolve-instance_method" title="JsonapiCompliable::Scope#resolve (method)">#resolve</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Scope.html#query_hash-instance_method" title="JsonapiCompliable::Scope#query_hash (method)">#query_hash</a></span>
       <small>JsonapiCompliable::Scope</small>
     </div>
   </li>
@@ -1518,16 +1486,32 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#resolve-instance_method" title="JsonapiCompliable::Resource#resolve (method)">#resolve</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#query_hash-instance_method" title="JsonapiCompliable::Scoping::Base#query_hash (method)">#query_hash</a></span>
+      <small>JsonapiCompliable::Scoping::Base</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#resolve-instance_method" title="JsonapiCompliable::Adapters::Abstract#resolve (method)">#resolve</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Configuration.html#raise_on_missing_sideload-instance_method" title="JsonapiCompliable::Configuration#raise_on_missing_sideload (method)">#raise_on_missing_sideload</a></span>
+      <small>JsonapiCompliable::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Deserializer.html#relationships-instance_method" title="JsonapiCompliable::Deserializer#relationships (method)">#relationships</a></span>
+      <small>JsonapiCompliable::Deserializer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Base.html#render_jsonapi-instance_method" title="JsonapiCompliable::Base#render_jsonapi (method)">#render_jsonapi</a></span>
+      <small>JsonapiCompliable::Base</small>
     </div>
   </li>
   
@@ -1542,13 +1526,37 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#resolve-instance_method" title="JsonapiCompliable::Adapters::Abstract#resolve (method)">#resolve</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#resolve-instance_method" title="JsonapiCompliable::Sideload#resolve (method)">#resolve</a></span>
       <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#resolve-instance_method" title="JsonapiCompliable::Resource#resolve (method)">#resolve</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scope.html#resolve-instance_method" title="JsonapiCompliable::Scope#resolve (method)">#resolve</a></span>
+      <small>JsonapiCompliable::Scope</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#resolve-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#resolve (method)">#resolve</a></span>
       <small>JsonapiCompliable::Adapters::ActiveRecord</small>
@@ -1556,34 +1564,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Scope.html#resolve_stats-instance_method" title="JsonapiCompliable::Scope#resolve_stats (method)">#resolve_stats</a></span>
       <small>JsonapiCompliable::Scope</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Query.html#resource-instance_method" title="JsonapiCompliable::Query#resource (method)">#resource</a></span>
-      <small>JsonapiCompliable::Query</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#resource-instance_method" title="JsonapiCompliable::Scoping::Base#resource (method)">#resource</a></span>
-      <small>JsonapiCompliable::Scoping::Base</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#resource-instance_method" title="JsonapiCompliable::Sideload#resource (method)">#resource</a></span>
-      <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
@@ -1598,13 +1582,37 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#resource_class-instance_method" title="JsonapiCompliable::Sideload#resource_class (method)">#resource_class</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#resource-instance_method" title="JsonapiCompliable::Sideload#resource (method)">#resource</a></span>
       <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
   <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Query.html#resource-instance_method" title="JsonapiCompliable::Query#resource (method)">#resource</a></span>
+      <small>JsonapiCompliable::Query</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Scoping/Base.html#resource-instance_method" title="JsonapiCompliable::Scoping::Base#resource (method)">#resource</a></span>
+      <small>JsonapiCompliable::Scoping::Base</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#resource_class-instance_method" title="JsonapiCompliable::Sideload#resource_class (method)">#resource_class</a></span>
+      <small>JsonapiCompliable::Sideload</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Util/Persistence.html#run-instance_method" title="JsonapiCompliable::Util::Persistence#run (method)">#run</a></span>
       <small>JsonapiCompliable::Util::Persistence</small>
@@ -1612,7 +1620,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#scope-instance_method" title="JsonapiCompliable::Sideload#scope (method)">#scope</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1620,7 +1628,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Sideload.html#scope_proc-instance_method" title="JsonapiCompliable::Sideload#scope_proc (method)">#scope_proc</a></span>
       <small>JsonapiCompliable::Sideload</small>
@@ -1628,18 +1636,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Util/IncludeParams.html#scrub-class_method" title="JsonapiCompliable::Util::IncludeParams.scrub (method)">scrub</a></span>
       <small>JsonapiCompliable::Util::IncludeParams</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sideload-instance_method" title="JsonapiCompliable::Resource#sideload (method)">#sideload</a></span>
-      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -1654,15 +1654,15 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Base.html#sideload_whitelist-instance_method" title="JsonapiCompliable::Base#sideload_whitelist (method)">#sideload_whitelist</a></span>
-      <small>JsonapiCompliable::Base</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sideload-instance_method" title="JsonapiCompliable::Resource#sideload (method)">#sideload</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Base.html#sideload_whitelist-class_method" title="JsonapiCompliable::Base.sideload_whitelist (method)">sideload_whitelist</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Base.html#sideload_whitelist-instance_method" title="JsonapiCompliable::Base#sideload_whitelist (method)">#sideload_whitelist</a></span>
       <small>JsonapiCompliable::Base</small>
     </div>
   </li>
@@ -1670,8 +1670,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sideloading-class_method" title="JsonapiCompliable::Resource.sideloading (method)">sideloading</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Base.html#sideload_whitelist-class_method" title="JsonapiCompliable::Base.sideload_whitelist (method)">sideload_whitelist</a></span>
+      <small>JsonapiCompliable::Base</small>
     </div>
   </li>
   
@@ -1686,8 +1686,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#sideloading_module-instance_method" title="JsonapiCompliable::Adapters::Abstract#sideloading_module (method)">#sideloading_module</a></span>
-      <small>JsonapiCompliable::Adapters::Abstract</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sideloading-class_method" title="JsonapiCompliable::Resource.sideloading (method)">sideloading</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
@@ -1702,55 +1702,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#sideloads-instance_method" title="JsonapiCompliable::Sideload#sideloads (method)">#sideloads</a></span>
-      <small>JsonapiCompliable::Sideload</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sort-class_method" title="JsonapiCompliable::Resource.sort (method)">sort</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sorting-instance_method" title="JsonapiCompliable::Resource#sorting (method)">#sorting</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#stat-instance_method" title="JsonapiCompliable::Resource#stat (method)">#stat</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#stats-instance_method" title="JsonapiCompliable::Resource#stats (method)">#stats</a></span>
-      <small>JsonapiCompliable::Resource</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/ValidationResponse.html#success%3F-instance_method" title="JsonapiCompliable::Util::ValidationResponse#success? (method)">#success?</a></span>
-      <small>JsonapiCompliable::Util::ValidationResponse</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#sum-instance_method" title="JsonapiCompliable::Adapters::Abstract#sum (method)">#sum</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#sideloading_module-instance_method" title="JsonapiCompliable::Adapters::Abstract#sideloading_module (method)">#sideloading_module</a></span>
       <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
@@ -1758,31 +1710,47 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#sum-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#sum (method)">#sum</a></span>
-      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+      <span class='object_link'><a href="JsonapiCompliable/Sideload.html#sideloads-instance_method" title="JsonapiCompliable::Sideload#sideloads (method)">#sideloads</a></span>
+      <small>JsonapiCompliable::Sideload</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#sum-instance_method" title="JsonapiCompliable::Adapters::Null#sum (method)">#sum</a></span>
-      <small>JsonapiCompliable::Adapters::Null</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sort-class_method" title="JsonapiCompliable::Resource.sort (method)">sort</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Stats/DSL.html#sum!-instance_method" title="JsonapiCompliable::Stats::DSL#sum! (method)">#sum!</a></span>
-      <small>JsonapiCompliable::Stats::DSL</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#sorting-instance_method" title="JsonapiCompliable::Resource#sorting (method)">#sorting</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Util/ValidationResponse.html#to_a-instance_method" title="JsonapiCompliable::Util::ValidationResponse#to_a (method)">#to_a</a></span>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#stat-instance_method" title="JsonapiCompliable::Resource#stat (method)">#stat</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#stats-instance_method" title="JsonapiCompliable::Resource#stats (method)">#stats</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Util/ValidationResponse.html#success%3F-instance_method" title="JsonapiCompliable::Util::ValidationResponse#success? (method)">#success?</a></span>
       <small>JsonapiCompliable::Util::ValidationResponse</small>
     </div>
   </li>
@@ -1790,8 +1758,56 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#sum-instance_method" title="JsonapiCompliable::Adapters::Null#sum (method)">#sum</a></span>
+      <small>JsonapiCompliable::Adapters::Null</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/ActiveRecord.html#sum-instance_method" title="JsonapiCompliable::Adapters::ActiveRecord#sum (method)">#sum</a></span>
+      <small>JsonapiCompliable::Adapters::ActiveRecord</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#sum-instance_method" title="JsonapiCompliable::Adapters::Abstract#sum (method)">#sum</a></span>
+      <small>JsonapiCompliable::Adapters::Abstract</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Stats/DSL.html#sum!-instance_method" title="JsonapiCompliable::Stats::DSL#sum! (method)">#sum!</a></span>
+      <small>JsonapiCompliable::Stats::DSL</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Util/ValidationResponse.html#to_a-instance_method" title="JsonapiCompliable::Util::ValidationResponse#to_a (method)">#to_a</a></span>
+      <small>JsonapiCompliable::Util::ValidationResponse</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Query.html#to_hash-instance_method" title="JsonapiCompliable::Query#to_hash (method)">#to_hash</a></span>
       <small>JsonapiCompliable::Query</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#transaction-instance_method" title="JsonapiCompliable::Adapters::Null#transaction (method)">#transaction</a></span>
+      <small>JsonapiCompliable::Adapters::Null</small>
     </div>
   </li>
   
@@ -1814,23 +1830,23 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Adapters/Null.html#transaction-instance_method" title="JsonapiCompliable::Adapters::Null#transaction (method)">#transaction</a></span>
-      <small>JsonapiCompliable::Adapters::Null</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Adapters/Abstract.html#transaction-instance_method" title="JsonapiCompliable::Adapters::Abstract#transaction (method)">#transaction</a></span>
       <small>JsonapiCompliable::Adapters::Abstract</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="JsonapiCompliable/Resource.html#type-instance_method" title="JsonapiCompliable::Resource#type (method)">#type</a></span>
+      <small>JsonapiCompliable::Resource</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#type-class_method" title="JsonapiCompliable::Resource.type (method)">type</a></span>
       <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
@@ -1846,8 +1862,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#type-class_method" title="JsonapiCompliable::Resource.type (method)">type</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable/Scope.html#unpaginated_object-instance_method" title="JsonapiCompliable::Scope#unpaginated_object (method)">#unpaginated_object</a></span>
+      <small>JsonapiCompliable::Scope</small>
     </div>
   </li>
   
@@ -1886,16 +1902,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable.html#with_context-class_method" title="JsonapiCompliable.with_context (method)">with_context</a></span>
-      <small>JsonapiCompliable</small>
+      <span class='object_link'><a href="JsonapiCompliable/Resource.html#with_context-instance_method" title="JsonapiCompliable::Resource#with_context (method)">#with_context</a></span>
+      <small>JsonapiCompliable::Resource</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="JsonapiCompliable/Resource.html#with_context-instance_method" title="JsonapiCompliable::Resource#with_context (method)">#with_context</a></span>
-      <small>JsonapiCompliable::Resource</small>
+      <span class='object_link'><a href="JsonapiCompliable.html#with_context-class_method" title="JsonapiCompliable.with_context (method)">with_context</a></span>
+      <small>JsonapiCompliable</small>
     </div>
   </li>
   

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Apr 18 07:58:11 2018 by
+  Generated on Thu May  3 15:52:17 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.9 (ruby-2.3.0).
 </div>

--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -14,6 +14,8 @@ module JsonapiCompliable
   #     scope.resolve #=> [#<Post ...>, #<Post ...>, etc]
   #   end
   class Scope
+    attr_reader :object, :unpaginated_object
+
     # @param object - The underlying, chainable base scope object
     # @param resource - The Resource that will process the object
     # @param query - The Query object for the current request

--- a/lib/jsonapi_compliable/version.rb
+++ b/lib/jsonapi_compliable/version.rb
@@ -1,3 +1,3 @@
 module JsonapiCompliable
-  VERSION = "0.11.4"
+  VERSION = "0.11.5"
 end


### PR DESCRIPTION
This allows direct access for non-standard usage, like putting facets in `meta`