### PR TITLE
Fix bug causing missing fields

### DIFF
--- a/lib/jsonapi_compliable/util/render_options.rb
+++ b/lib/jsonapi_compliable/util/render_options.rb
@@ -16,8 +16,8 @@ module JsonapiCompliable
         extra_fields = query_hash[:extra_fields]
 
         # Ensure fields doesnt clobber extra fields
-        if extra_fields.any? && fields.any?
-          extra_fields.each { |k,v| fields[k] = fields[k].to_a + v }
+        extra_fields.each do |k,v|
+          fields[k] = fields[k] + v if fields[k]
         end
 
         options            = {}

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -304,6 +304,22 @@ if ENV["APPRAISAL_INITIALIZED"]
         expect(hobby).to_not have_key('description')
       end
 
+      it 'allows extra fields and sparse fieldsets for multiple resources' do
+        get :index, params: {
+          include: 'hobbies,books',
+          fields: { hobbies: 'name', books: 'title',  },
+          extra_fields: { hobbies: 'reason', books: 'alternate_title' },
+        }
+        hobby = json_includes('hobbies')[0]['attributes']
+        book = json_includes('books')[0]['attributes']
+        expect(hobby).to have_key('name')
+        expect(hobby).to have_key('reason')
+        expect(hobby).to_not have_key('description')
+        expect(book).to have_key('title')
+        expect(book).to have_key('alternate_title')
+        expect(book).to_not have_key('pages')
+      end
+
       it 'does not duplicate results' do
         get :index, params: { include: 'hobbies' }
         author1_relationships = json['data'][0]['relationships']


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/jsonapi-suite/jsonapi_compliable/pull/77 that results in missing fields for one or more resources when the following conditions are met:

- sparse fields _are not_ specified for resource `A`
- extra fields _are_ specified for resource `A`
- sparse fields _are_ specified for resource `B`

For example:
`/api/posts?include=author&extra_fields[posts]=comment_count&fields[author]=name`

Would yield the following payload:
```javascript
{
  "data": [
    {
      "type": "posts",
      "attributes": {
        "comment_count": 1 // missing default fields!
      }
    }
  ],
  "included": [
    {
      "type": "authors",
      "attributes": {
        "name": "John"
      }
    }
  ]
}
```
