### PR TITLE
Add overridable jsonapi_context

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -130,9 +130,29 @@ module JsonapiCompliable
     # @api private
     # @yieldreturn Code to run within the current context
     def wrap_context
-      jsonapi_resource.with_context(self, action_name.to_sym) do
+      jsonapi_resource.with_context(jsonapi_context, action_name.to_sym) do
         yield
       end
+    end
+
+    # Override if you'd like the "context" to be something other than
+    # an instance of this class.
+    # In Rails, context is the controller instance.
+    #
+    # @example Overriding
+    #   # within your controller
+    #   def jsonapi_context
+    #     current_user
+    #   end
+    #
+    #   # within a resource
+    #   default_filter :by_user do |scope, context|
+    #     scope.where(user_id: context.id)
+    #   end
+    #
+    # @return the context object you'd like
+    def jsonapi_context
+      self
     end
 
     # Use when direct, low-level access to the scope is required.

--- a/spec/jsonapi_compliable_spec.rb
+++ b/spec/jsonapi_compliable_spec.rb
@@ -84,6 +84,21 @@ RSpec.describe JsonapiCompliable do
     end
   end
 
+  describe '#jsonapi_context' do
+    let(:ctx) { double('context') }
+
+    before do
+      allow(instance).to receive(:jsonapi_context) { ctx }
+      allow(instance).to receive(:action_name) { 'index' }
+    end
+
+    it 'sets the context to the given override' do
+      instance.wrap_context do
+        expect(instance.jsonapi_resource.context).to eq(ctx)
+      end
+    end
+  end
+
   describe '#render_jsonapi' do
     before do
       allow(instance).to receive(:force_includes?) { false }


### PR DESCRIPTION
This allows developers to set "context" as whatever they'd like