### PR TITLE
Add ability to require a filter to be provided

### DIFF
--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -47,5 +47,19 @@ module JsonapiCompliable
 
     class RecordNotFound < StandardError
     end
+
+    class RequiredFilter < StandardError
+      def initialize(attributes)
+        @attributes = Array(attributes)
+      end
+
+      def message
+        if @attributes.length > 1
+          "The required filters \"#{@attributes.join(', ')}\" were not provided"
+        else
+          "The required filter \"#{@attributes[0]}\" was not provided"
+        end
+      end
+    end
   end
 end

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -172,7 +172,8 @@ module JsonapiCompliable
       config[:filters][name.to_sym] = {
         aliases: aliases,
         if: opts[:if],
-        filter: blk
+        filter: blk,
+        required: opts[:required].respond_to?(:call) ? opts[:required] : !!opts[:required]
       }
     end
 

--- a/lib/jsonapi_compliable/scoping/filter.rb
+++ b/lib/jsonapi_compliable/scoping/filter.rb
@@ -28,6 +28,7 @@ module JsonapiCompliable
     # aliases. If valid, call either the default or custom filtering logic.
     # @return the scope we are chaining/modifying
     def apply
+      raise JsonapiCompliable::Errors::RequiredFilter.new(missing_required_filters) unless required_filters_provided?
       each_filter do |filter, value|
         @scope = filter_scope(filter, value)
       end

--- a/lib/jsonapi_compliable/scoping/filterable.rb
+++ b/lib/jsonapi_compliable/scoping/filterable.rb
@@ -23,5 +23,19 @@ module JsonapiCompliable
     def filter_param
       query_hash[:filter]
     end
+
+    def missing_required_filters
+      required_filters.keys - filter_param.keys
+    end
+
+    def required_filters
+      resource.filters.select do |_name, opts|
+        opts[:required].respond_to?(:call) ? opts[:required].call(resource.context) : opts[:required]
+      end
+    end
+
+    def required_filters_provided?
+      missing_required_filters.empty?
+    end
   end
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -208,4 +208,92 @@ RSpec.describe 'filtering' do
       }.to raise_error(JsonapiCompliable::Errors::BadFilter)
     end
   end
+
+  context 'when one or more filters are required' do
+    before do
+      author = author1
+      resource_class.class_eval do
+        allow_filter :required, required: true do |scope, value|
+          scope.where(id: author.id)
+        end
+
+        allow_filter :also_required, required: true do |scope, value|
+          scope.where(first_name: author.first_name)
+        end
+      end
+    end
+
+    context 'and all required filter are provided' do
+      before do
+        params[:filter] = { required: true, also_required: true }
+      end
+
+      it 'should return results' do
+        ids = scope.resolve.map(&:id)
+        expect(ids).to eq([author1.id])
+      end
+    end
+
+    context 'and at least one required filter is provided but some are missing' do
+      before do
+        params[:filter] = { required: true }
+      end
+
+      it 'raises an error' do
+        expect {
+          scope.resolve
+        }.to raise_error(JsonapiCompliable::Errors::RequiredFilter, 'The required filter "also_required" was not provided')
+      end
+    end
+
+    context 'and no required filters are provided' do
+      before do
+        params[:filter] = { }
+      end
+
+      it 'raises an error' do
+        expect {
+          scope.resolve
+        }.to raise_error(JsonapiCompliable::Errors::RequiredFilter, 'The required filters "required, also_required" were not provided')
+      end
+
+    end
+
+    context 'and required filter determined by proc' do
+      context 'when required proc evaluates to true' do
+        before do
+          resource_class.class_eval do
+            allow_filter :required_by_proc, required: Proc.new{|ctx| true} do |scope, value|
+              scope.where(first_name: author.first_name)
+            end
+          end
+
+          params[:filter] = { required: true, also_required: true }
+        end
+
+        it 'raises an error' do
+          expect {
+            scope.resolve
+          }.to raise_error(JsonapiCompliable::Errors::RequiredFilter, 'The required filter "required_by_proc" was not provided')
+        end
+      end
+
+      context 'when required proc evaluates to false' do
+        before do
+          resource_class.class_eval do
+            allow_filter :required_by_proc, required: Proc.new{|ctx| false} do |scope, value|
+              scope.where(first_name: author.first_name)
+            end
+          end
+
+          params[:filter] = { required: true, also_required: true }
+        end
+
+        it 'should not be required' do
+          ids = scope.resolve.map(&:id)
+          expect(ids).to eq([author1.id])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I should be allowed to require a consumer to provide one or more filters
to prevent cart-blanche querying to the API.