### PR TITLE
Test required filters through sideload work

### DIFF
--- a/lib/jsonapi_compliable/query.rb
+++ b/lib/jsonapi_compliable/query.rb
@@ -209,7 +209,8 @@ module JsonapiCompliable
           key = key.to_sym
 
           if association?(key)
-            hash[key][:filter].merge!(value)
+            k, v = Hash(value).to_a.first
+            hash[key][:filter][k.to_sym] = v
           else
             hash[resource.type][:filter][key] = value
           end


### PR DESCRIPTION
Discovered that sideloaded filters have a string key whereas regular
filters have a symbolized key.  Changed query#parse_filter to make
this consistent and added required filter test for sideloaded
resources.