### PR TITLE
Ensure has_one artificially limits

### DIFF
--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -64,6 +64,7 @@ module JsonapiCompliable
         []
       else
         resolved = @resource.resolve(@object)
+        yield resolved if block_given?
         sideload(resolved, query_hash[:include]) if query_hash[:include]
         resolved
       end

--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -399,8 +399,9 @@ module JsonapiCompliable
     def resolve_basic(parents, query, namespace)
       sideload_scope   = scope_proc.call(parents)
       sideload_scope   = Scope.new(sideload_scope, resource_class.new, query, default_paginate: false, namespace: namespace)
-      sideload_results = sideload_scope.resolve
-      assign_proc.call(parents, sideload_results)
+      sideload_scope.resolve do |sideload_results|
+        assign_proc.call(parents, sideload_results)
+      end
     end
   end
 end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -40,6 +40,10 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :picture
   end
 
+  create_table :bio_labels do |t|
+    t.integer :bio_id
+  end
+
   create_table :genres do |t|
     t.string :name
     t.timestamps
@@ -111,6 +115,11 @@ end
 
 class Bio < LegacyApplicationRecord
   belongs_to :author
+  has_many :bio_labels
+end
+
+class BioLabel < LegacyApplicationRecord
+  belongs_to :bio
 end
 
 class Genre < LegacyApplicationRecord
@@ -213,6 +222,12 @@ class SerializableBio < LegacySerializableAbstract
   extra_attribute :created_at do
     Time.now
   end
+
+  has_many :bio_labels
+end
+
+class SerializableBioLabel < LegacySerializableAbstract
+  type 'bio_labels'
 end
 
 class SerializableState < LegacySerializableAbstract

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -77,7 +77,11 @@ RSpec.describe JsonapiCompliable::Sideload do
       let(:results)    { [{ parent_id: 1 }] }
       let(:base_scope) { double }
       let(:scope_proc) { ->(parents) { base_scope } }
-      let(:scope)      { double(resolve: results) }
+      let(:scope) do
+        scope = double
+        allow(scope).to receive(:resolve).and_yield(results)
+        scope
+      end
 
       before do
         instance.scope  { |parents| base_scope }


### PR DESCRIPTION
We don't want to `limit(1)` a has_one. If a Post has_one Detail, and we were
listing all posts and sideloading their detail, only one *total* detail
would be in the response.

So we can't paginate, and instead we assign only the relevant children.
The work done here is to remove the excessive results from the array.
This is important because subsequent sideloads will scope to that array.

To make this work, we ensure the `assign` block is fired before
processing further sideloads, which makes better mental sense in any
case.

See also: https://github.com/rails/rails/issues/10621