### PR TITLE
Fix local test failure

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -288,7 +288,11 @@ module JsonapiCompliable
       opts  = default_jsonapi_render_options.merge(opts)
       opts  = Util::RenderOptions.generate(scope, query_hash, opts)
       opts[:expose][:context] = self
-      opts[:include] ||= deserialized_params.include_directive if force_includes?
+
+      if opts[:include].empty? && force_includes?
+        opts[:include] = deserialized_params.include_directive
+      end
+
       perform_render_jsonapi(opts)
     end
 


### PR DESCRIPTION
...that was passing in CI. In any case, the logic here is correct -
`||=` will not assign if `opts[:include]` is an empty hash.