### PR TITLE
Allow for per-action resources

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -106,7 +106,14 @@ module JsonapiCompliable
     #
     # @return [Resource] the configured Resource for this controller
     def jsonapi_resource
-      @jsonapi_resource ||= self.class._jsonapi_compliable.new
+      @jsonapi_resource ||= begin
+        resource = self.class._jsonapi_compliable
+        if resource.is_a?(Hash)
+          resource[action_name.to_sym].new
+        else
+          resource.new
+        end
+      end
     end
 
     # Instantiates the relevant Query object


### PR DESCRIPTION
Sometimes you want `index` powered by ElasticSearch but `show` is a
normal ActiveRecord Resource. While we still support the existing
syntax, you can now pass a hash of per-action Resources:

```ruby
class PostsController < ApplicationController
  jsonapi resource: {
    index: PostSearchResource,
    show: PostResource
  }
end
```