### PR TITLE
1.0: Major spec refactor

### DIFF
--- a/lib/jsonapi_compliable/extensions/extra_attribute.rb
+++ b/lib/jsonapi_compliable/extensions/extra_attribute.rb
@@ -46,7 +46,9 @@ module JsonapiCompliable
               next false unless instance_eval(&options[:if])
             end
 
-            @extra_fields[@_type] && @extra_fields[@_type].include?(name)
+            @extra_fields &&
+              @extra_fields[@_type] &&
+              @extra_fields[@_type].include?(name)
           }
 
           attribute name, if: allow_field, &blk

--- a/lib/jsonapi_compliable/query.rb
+++ b/lib/jsonapi_compliable/query.rb
@@ -245,7 +245,8 @@ module JsonapiCompliable
           if [:number, :size].include?(key)
             hash[resource.type][:page][key] = value.to_i
           else
-            hash[key][:page] = { number: value[:number].to_i, size: value[:size].to_i }
+            number = value[:number].to_i if value[:number]
+            hash[key][:page] = { number: number, size: value[:size].to_i }
           end
         end
       end

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -354,12 +354,6 @@ module JsonapiCompliable
       config[:type] = value
     end
 
-    # Set an alternative default page number. Defaults to 1.
-    # @param [Integer] val The new default
-    def self.default_page_number(val)
-      config[:default_page_number] = val
-    end
-
     # Set an alternate default page size, when not specified in query parameters.
     #
     # @example
@@ -558,12 +552,6 @@ module JsonapiCompliable
     # @api private
     def default_sort
       self.class.config[:default_sort] || []
-    end
-
-    # @see .default_page_number
-    # @api private
-    def default_page_number
-      self.class.config[:default_page_number] || 1
     end
 
     # @see .default_page_size

--- a/lib/jsonapi_compliable/scoping/paginate.rb
+++ b/lib/jsonapi_compliable/scoping/paginate.rb
@@ -77,7 +77,7 @@ module JsonapiCompliable
     end
 
     def number
-      (page_param[:number] || resource.default_page_number).to_i
+      (page_param[:number] || 1).to_i
     end
 
     def size

--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -116,32 +116,32 @@ module JsonapiCompliable
       end
     end
 
-    #def after_save(only: [], except: [], &blk)
-      #actions = HOOK_ACTIONS - except
-      #actions = only & actions
-      #actions = [:save] if only.empty? && except.empty?
-      #actions.each do |a|
-        #hooks[:"after_#{a}"] << blk
-      #end
-    #end
+    def self.after_save(only: [], except: [], &blk)
+      actions = HOOK_ACTIONS - except
+      actions = only & actions
+      actions = [:save] if only.empty? && except.empty?
+      actions.each do |a|
+        hooks[:"after_#{a}"] << blk
+      end
+    end
 
-    #def hooks
-      #@hooks ||= {}.tap do |h|
-        #HOOK_ACTIONS.each do |a|
-          #h[:"after_#{a}"] = []
-          #h[:"before_#{a}"] = []
-        #end
-      #end
-    #end
+    def self.hooks
+      @hooks ||= {}.tap do |h|
+        HOOK_ACTIONS.each do |a|
+          h[:"after_#{a}"] = []
+          h[:"before_#{a}"] = []
+        end
+      end
+    end
 
-    #def fire_hooks!(parent, objects, method)
-      #return unless self.hooks
+    def self.fire_hooks!(parent, objects, method)
+      return unless self.hooks
 
-      #hooks = self.hooks[:"after_#{method}"] + self.hooks[:after_save]
-      #hooks.compact.each do |hook|
-        #resource.instance_exec(parent, objects, &hook)
-      #end
-    #end
+      hooks = self.hooks[:"after_#{method}"] + self.hooks[:after_save]
+      hooks.compact.each do |hook|
+        resource.instance_exec(parent, objects, &hook)
+      end
+    end
 
     private
 

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -170,9 +170,9 @@ end
   #model Salary
 #end
 
-#class EmployeeResource < ApplicationResource
-  #type :employees
-  #model Employee
+class EmployeeResource < ApplicationResource
+  type :employees
+  model Employee
 
   #belongs_to :classification,
     #scope: -> { Classification.all },
@@ -205,7 +205,7 @@ end
         #foreign_key: :workspace_id
       #}
     #}
-#end
+end
 
 class SerializableAbstract < JSONAPI::Serializable::Resource
 end
@@ -222,19 +222,19 @@ end
   #attribute :name
 #end
 
-#class SerializableEmployee < SerializableAbstract
-  #type 'employees'
+class SerializableEmployee < SerializableAbstract
+  type 'employees'
 
-  #attribute :first_name
-  #attribute :last_name
-  #attribute :age
+  attribute :first_name
+  attribute :last_name
+  attribute :age
 
   #belongs_to :classification
   #has_many :positions
   #has_many :teams
 
   #has_one :salary
-#end
+end
 
 class SerializablePosition < SerializableAbstract
   type 'positions'

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -8,6 +8,7 @@ module PORO
             positions: [],
             departments: [],
             bios: [],
+            team_memberships: [],
             teams: []
           }
       end
@@ -39,14 +40,19 @@ module PORO
 
       private
 
+      # TODO: the integer casting here should go away with attribute types
       def apply_filtering(records, params)
         return records unless params[:conditions]
         records.select! do |record|
           params[:conditions].all? do |key, value|
+            db_value = record.send(key)
+            if key == :id
+              value = value.is_a?(Array) ? value.map(&:to_i) : value.to_i
+            end
             if value.is_a?(Array)
-              value.include?(record.send(key))
+              value.include?(db_value)
             else
-              record.send(key) == value
+              db_value == value
             end
           end
         end
@@ -54,18 +60,25 @@ module PORO
       end
 
       def apply_sorting(records, params)
-        return records unless params[:sort]
-        records.sort! do |a, b|
-          att = params[:sort].keys[0]
-          a.send(att) <=> b.send(att)
+        return records if params[:sort].nil?
+
+        params[:sort].reverse.each do |sort|
+          records.sort! do |a, b|
+            att = sort.keys[0]
+            a.send(att) <=> b.send(att)
+          end
+          records = records.reverse if sort.values[0] == :desc
         end
-        records = records.reverse if params[:sort].values[0] == :desc
         records
       end
 
       def apply_pagination(records, params)
         return records unless params[:per]
-        records.take(params[:per])
+
+        start_at = (params[:page]-1)*(params[:per])
+        end_at = (params[:page] * params[:per]) -1
+        return [] if end_at < 0
+        records[start_at..end_at]
       end
     end
   end
@@ -73,14 +86,32 @@ module PORO
   class Base
     attr_accessor :id
 
+    def self.create(attrs = {})
+      id = DB.data[type].length + 1
+      attrs = { id: id }.merge(attrs)
+      DB.data[type] << attrs
+      new(attrs)
+    end
+
+    def self.type
+      name.underscore.pluralize.split('/').last.to_sym
+    end
+
     def initialize(attrs = {})
       attrs.each_pair { |k,v| send(:"#{k}=", v) }
+    end
+
+    def update_attributes(attrs)
+      record = DB.data[self.class.type].find { |r| r[:id] == id }
+      record.merge!(attrs)
     end
   end
 
   class Employee < Base
     attr_accessor :first_name,
       :last_name,
+      :age,
+      :active,
       :positions,
       :bio,
       :teams
@@ -117,16 +148,47 @@ module PORO
     attr_accessor :name, :team_memberships
   end
 
-  class ApplicationResource < JsonapiCompliable::Resource
-    use_adapter JsonapiCompliable::Adapters::Null
-
-    sort do |scope, att, dir|
-      scope.merge!(sort: { att => dir })
+  class Adapter < JsonapiCompliable::Adapters::Null
+    def order(scope, att, dir)
+      scope[:sort] ||= []
+      scope[:sort] << { att => dir }
+      scope
     end
 
-    paginate do |scope, current_page, per_page|
+    def paginate(scope, current_page, per_page)
       scope.merge!(page: current_page, per: per_page)
     end
+
+    def filter(scope, name, value)
+      scope[:conditions] ||= {}
+      scope[:conditions].merge!(name => value)
+      scope
+    end
+
+    # No need for actual logic to fire
+    def count(scope, attr)
+       "poro_count_#{attr}"
+    end
+
+    def sum(scope, attr)
+      "poro_sum_#{attr}"
+    end
+
+    def average(scope, attr)
+      "poro_average_#{attr}"
+    end
+
+    def maximum(scope, attr)
+      "poro_maximum_#{attr}"
+    end
+
+    def minimum(scope, attr)
+      "poro_minimum_#{attr}"
+    end
+  end
+
+  class ApplicationResource < JsonapiCompliable::Resource
+    use_adapter Adapter
 
     def resolve(scope)
       ::PORO::DB.all(scope)
@@ -165,6 +227,24 @@ module PORO
 
     attribute :first_name
     attribute :last_name
+    attribute :age
+
+    is_admin = proc { |c| @context && @context.current_user == 'admin' }
+    attribute :salary, if: is_admin do
+      100_000
+    end
+
+    extra_attribute :stack_ranking do
+      rand(999)
+    end
+
+    extra_attribute :admin_stack_ranking, if: is_admin do
+      rand(999)
+    end
+
+    extra_attribute :runtime_id do
+      @context.runtime_id
+    end
 
     has_many :positions
     has_many :teams

--- a/spec/integration/rails/hooks_spec.rb
+++ b/spec/integration/rails/hooks_spec.rb
@@ -17,8 +17,8 @@ if ENV["APPRAISAL_INITIALIZED"]
     end
 
     module IntegrationHooks
-      class ApplicationRecord < JsonapiCompliable::Resource
-        use_adapter JsonapiCompliable::Adapters::ActiveRecord
+      class ApplicationResource < JsonapiCompliable::Resource
+        use_adapter JsonapiCompliable::Adapters::ActiveRecord::Base
       end
 
       class BookResource < ApplicationResource
@@ -31,12 +31,10 @@ if ENV["APPRAISAL_INITIALIZED"]
         model State
       end
 
-      class AuthorResource < ApplicationResourcce
+      class AuthorResource < ApplicationResource
         model Author
 
         has_many :books,
-          foreign_key: :author_id,
-          scope: -> { Book.all },
           resource: BookResource do
             after_save only: [:create] do |author, books|
               Callbacks.fired[:after_create] = [author, books]
@@ -60,8 +58,6 @@ if ENV["APPRAISAL_INITIALIZED"]
           end
 
         belongs_to :state,
-          foreign_key: :state_id,
-          scope: -> { State.all },
           resource: StateResource do
             after_save only: [:create] do |author, states|
               Callbacks.fired[:state_after_create] = [author, states]

--- a/spec/jsonapi_compliable_spec.rb
+++ b/spec/jsonapi_compliable_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe JsonapiCompliable do
       attr_accessor :params
       include JsonapiCompliable::Base
 
-      jsonapi do
-        type :authors
-      end
+      jsonapi resource: PORO::EmployeeResource
 
       def params
         @params || {}
@@ -20,53 +18,23 @@ RSpec.describe JsonapiCompliable do
 
   describe '.jsonapi' do
     let(:subclass1) do
-      Class.new(klass) do
-        jsonapi do
-          type :subclass_1
-          allow_filter :id
-          allow_filter :foo
-        end
-      end
+      Class.new(klass)
     end
 
     let(:subclass2) do
       Class.new(subclass1) do
-        jsonapi do
-          type :subclass_2
-          allow_filter :foo do |scope, value|
-            'foo'
-          end
-        end
+        jsonapi resource: PORO::PositionResource
       end
-    end
-
-    it 'assigns a subclass of Resource by default' do
-      expect(klass._jsonapi_compliable.ancestors)
-        .to include(JsonapiCompliable::Resource)
-      expect(klass._jsonapi_compliable.object_id)
-        .to_not eq(JsonapiCompliable::Resource.object_id)
     end
 
     context 'when subclassing and customizing' do
-      def config(obj)
-        obj._jsonapi_compliable.config
-      end
-
       it 'preserves values from superclass' do
-        expect(config(subclass2)[:filters][:id]).to_not be_nil
+        expect(subclass1._jsonapi_compliable.config[:type]).to eq(:employees)
       end
 
-      it 'does not alter superclass when overriding' do
-        expect(config(subclass1)).to_not eq(config(subclass2))
-        expect(config(subclass1)[:filters][:id].object_id)
-          .to_not eq(config(subclass2)[:filters][:id].object_id)
-        expect(config(subclass1)[:filters][:foo][:filter]).to be_nil
-        expect(config(subclass2)[:filters][:foo][:filter]).to_not be_nil
-      end
-
-      it 'overrides type for subclass' do
-        expect(config(subclass2)[:type]).to eq(:subclass_2)
-        expect(config(subclass1)[:type]).to eq(:subclass_1)
+      it 'can override in subclass' do
+        expect(subclass1._jsonapi_compliable.config[:type]).to eq(:employees)
+        expect(subclass2._jsonapi_compliable.config[:type]).to eq(:positions)
       end
     end
   end
@@ -105,34 +73,28 @@ RSpec.describe JsonapiCompliable do
     end
 
     it 'is able to override options' do
-      author = Author.create!(first_name: 'Stephen', last_name: 'King')
-      author.books.create(title: "The Shining", genre: Genre.new(name: 'horror'))
-
-      expect(instance).to receive(:perform_render_jsonapi).with(hash_including(meta: { foo: 'bar' }))
-      instance.render_jsonapi(Author.all, { scope: false, meta: { foo: 'bar' } })
+      expect(instance).to receive(:perform_render_jsonapi)
+        .with(hash_including(meta: { foo: 'bar' }))
+      instance.render_jsonapi([], {
+        scope: false, meta: { foo: 'bar' }
+      })
     end
 
     context 'when passing scope: false' do
       it 'does not appy jsonapi_scope' do
-        instance.params = { include: 'books.genre,foo' }
-        author = double
-        allow(Author).to receive(:all).and_return([author])
-        expect(Author).to_not receive(:find_by_sql)
-        expect(author).to_not receive(:includes)
-        expect(instance).to_not receive(:jsonapi_scope)
-
-        instance.render_jsonapi(Author.all, scope: false)
-      end
-    end
-    context 'when passing manual scope' do
-      it 'passes the manually included scope' do
-        author = Author.create!(first_name: 'Stephen', last_name: 'King')
-        author.books.create(title: "The Shining", genre: Genre.new(name: 'horror'))
-
-        expect(instance).to receive(:perform_render_jsonapi).with(hash_including(include: { foo: {}}))
-        instance.render_jsonapi(Author.all, { include: { foo: {} }, scope: false, meta: { foo: 'bar' } })
+        expect(PORO::DB).to_not receive(:all)
+        instance.render_jsonapi([], scope: false)
       end
     end
 
+    context 'when passing manual :include' do
+      it 'respects the :include option' do
+        expect(instance).to receive(:perform_render_jsonapi)
+          .with(hash_including(include: { foo: {}}))
+        instance.render_jsonapi([], {
+          include: { foo: {} }, scope: false, meta: { foo: 'bar' }
+        })
+      end
+    end
   end
 end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -79,18 +79,7 @@ RSpec.describe JsonapiCompliable::Resource do
     end
 
     it 'defaults' do
-      expect(instance.default_sort).to eq([{ id: :asc }])
-    end
-  end
-
-  describe '#default_page_number' do
-    it 'gets/sets correctly' do
-      klass.default_page_number(2)
-      expect(instance.default_page_number).to eq(2)
-    end
-
-    it 'defaults' do
-      expect(instance.default_page_number).to eq(1)
+      expect(instance.default_sort).to eq([])
     end
   end
 
@@ -158,24 +147,22 @@ RSpec.describe JsonapiCompliable::Resource do
     end
   end
 
-  describe '#association_names' do
+  describe '.association_names' do
     it 'collects nested + resource sideloads' do
-      klass.allow_sideload :books do
-        genre_resource = Class.new(JsonapiCompliable::Resource) do
-          allow_sideload :from_genre_resource do
-            allow_sideload :nested_from_genre_resource
-          end
+      position_resource = Class.new(PORO::PositionResource) do
+        belongs_to :department
+        def self.name
+          'PORO::PositionResource'
         end
-        allow_sideload :genre, resource: genre_resource
       end
-      klass.allow_sideload :state, polymorphic: true
-      expect(instance.association_names)
-        .to match_array([:books, :genre, :state, :from_genre_resource, :nested_from_genre_resource])
+      klass.has_many :positions, resource: position_resource
+      expect(klass.association_names)
+        .to match_array([:positions, :department])
     end
 
     context 'when no whitelist' do
       it 'defaults to empty array' do
-        expect(instance.association_names).to eq([])
+        expect(klass.association_names).to eq([])
       end
     end
   end

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe JsonapiCompliable::Scope do
   let(:object)     { double.as_null_object }
   let(:query_hash) { JsonapiCompliable::Query.default_hash }
-  let(:query)      { double(to_hash: { authors: query_hash }) }
+  let(:query)      { double(to_hash: { employees: query_hash }) }
   let(:instance)   { described_class.new(object, resource, query) }
 
   let(:resource) do
-    dbl = double type: :authors,
+    dbl = double type: :employees,
       default_page_size: 1,
       pagination: nil
     dbl.as_null_object
@@ -30,18 +30,18 @@ RSpec.describe JsonapiCompliable::Scope do
     end
 
     context 'when sideloading' do
-      let(:sideload) { double(name: :books) }
+      let(:sideload) { double(name: :positions) }
       let(:results)  { double }
 
       before do
-        query_hash[:include] = { books: {} }
+        query_hash[:include] = { positions: {} }
         objekt = instance.instance_variable_get(:@object)
         allow(resource).to receive(:resolve).with(objekt) { results }
       end
 
       context 'when the requested sideload exists on the resource' do
         before do
-          allow(resource).to receive(:sideload).with(:books) { sideload }
+          allow(resource.class).to receive(:sideload).with(:positions) { sideload }
         end
 
         it 'resolves the sideload' do
@@ -66,13 +66,13 @@ RSpec.describe JsonapiCompliable::Scope do
 
       context 'when the requested sideload does not exist' do
         before do
-          allow(resource).to receive(:sideload).with(:books) { nil }
+          allow(resource.class).to receive(:sideload).with(:positions) { nil }
         end
 
         it 'raises a helpful error' do
           expect {
             instance.resolve
-          }.to raise_error(JsonapiCompliable::Errors::InvalidInclude, 'The requested included relationship "books" is not supported on resource "authors"')
+          }.to raise_error(JsonapiCompliable::Errors::InvalidInclude)
         end
 
         context 'but the config says not to raise errors' do

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'sideloading' do
 
     class PositionSideload < ::JsonapiCompliable::Sideload::HasMany
       def scope(employees)
-        { type: :positions, sort: { id: :desc } }
+        { type: :positions, sort: [{ id: :desc }] }
       end
     end
   end
@@ -23,16 +23,28 @@ RSpec.describe 'sideloading' do
     PORO::DB.clear
   end
 
-  before do
-    PORO::DB.data[:employees] << { id: 1  }
-    PORO::DB.data[:positions] << { id: 1, employee_id: 1, department_id: 1  }
-    PORO::DB.data[:positions] << { id: 2, employee_id: 1, department_id: 2  }
-    PORO::DB.data[:departments] << { id: 1 }
-    PORO::DB.data[:departments] << { id: 2 }
-    PORO::DB.data[:bios] << { id: 1, employee_id: 1  }
-    PORO::DB.data[:bios] << { id: 2, employee_id: 1  }
-    PORO::DB.data[:teams] << { id: 1, team_memberships: [PORO::TeamMembership.new(employee_id: 1, team_id: 1)] }
-    PORO::DB.data[:teams] << { id: 2, team_memberships: [PORO::TeamMembership.new(employee_id: 1, team_id: 2)] }
+  let!(:employee) { PORO::Employee.create }
+  let!(:position1) do
+    PORO::Position.create employee_id: employee.id,
+      department_id: department1.id
+  end
+  let!(:position2) do
+    PORO::Position.create employee_id: employee.id,
+      department_id: department2.id
+  end
+  let!(:department1) { PORO::Department.create }
+  let!(:department2) { PORO::Department.create }
+  let!(:bio1) { PORO::Bio.create(employee_id: employee.id) }
+  let!(:bio2) { PORO::Bio.create(employee_id: employee.id) }
+  let!(:team1) do
+    PORO::Team.create team_memberships: [
+      PORO::TeamMembership.new(employee_id: employee.id, team_id: 1)
+    ]
+  end
+  let!(:team2) do
+    PORO::Team.create team_memberships: [
+      PORO::TeamMembership.new(employee_id: employee.id, team_id: 2)
+    ]
   end
 
   context 'when basic manual sideloading' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ require 'jsonapi_compliable/adapters/null'
 require 'jsonapi_compliable/adapters/active_record'
 
 RSpec.configure do |config|
+  config.after do
+    PORO::DB.clear
+  end
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/stats/dsl_spec.rb
+++ b/spec/stats/dsl_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe JsonapiCompliable::Stats::DSL do
   let(:config)   { :myattr }
-  let(:adapter)  { JsonapiCompliable::Adapters::ActiveRecord.new }
+  let(:adapter)  { JsonapiCompliable::Adapters::ActiveRecord::Base.new }
   let(:instance) { described_class.new(adapter, config) }
 
   describe '.new' do


### PR DESCRIPTION
So we have three groups of tests:

* Unit tests, WYSIWYG. Ex: `spec/sideload_spec.rb`. This is where we'd
test that, say, the correct resource name is derived.
* "Functional" tests, which test behavior of the low-level API. Ex:
`spec/sideloading_spec.rb`. Here we'll actually call the low-level
`allow_sideload` API, with a variety of different options, but without
going through a full application stack.
* "Integration" tests, which uses request specs to test Rails with
ActiveRecord end-to-end.

The last two groups can seem conceptually fuzzy and there is definitely some
overlap. The "functional" tests still used ActiveRecord, for instance
(this was mostly for convenience at the time).

This refactors all tests in the first two groups to use POROs (defined
in `spec/fixtures/poro.rb`), and to use the same domain (employee
directory) across all tests. The only non-ED tests are in
`spec/integration/rails/*`, which I'm avoiding touching now because they
are the best verification of E2E suite behavior.

This better ensures we are decoupled from AR, and by its nature builds
better support for PORO use cases (which are the common - even if you
are using elasticsearch you may return POROish models).

It also validates "resource testing", which will largely replace request
specs. This allows us to test resource behavior, including rendered
JSON, without going through a controller or endpoint. If this is going
to be the testing pattern for real-world apps, let's leverage that same
testing pattern internally (dogfood).

It also sets us up to remove Rails/ActiveRecord from the testing stack
altogether. I'd like a separate "adapter test suite" to emerge, where
"as long as these tests pass, your adapter is considered working".
Rails/ActiveRecord could still live within this gem, but be the exemplar
implementation of that test suite. This allows "official" adapters to be
published, so we can leverage the work of our open-source community to
provide adapters for MongoDB, ElasticSearch and Neo4J amonst others.

All tests now pass except for the write-specific Rails Integration
tests, which will be tackled later.

Other touches:

* Removed `default_page_number`. I can't imagine when this would be
anything but `1`.

Still todo:

* Use `jsonapi_spec_helpers` instead of the custom helpers there now.
