### PR TITLE
Hook up writes to 1.0 API

### DIFF
--- a/jsonapi_compliable.gemspec
+++ b/jsonapi_compliable.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   # Pinning this version until backwards-incompatibility is addressed
   spec.add_dependency 'jsonapi-serializable', '~> 0.3.0'
   spec.add_dependency 'dry-types', '~> 0.13'
+  spec.add_dependency 'jsonapi_errorable', '~> 0.9'
 
   spec.add_development_dependency "activerecord", ['>= 4.1', '< 6']
   spec.add_development_dependency "kaminari", '~> 0.17'
@@ -27,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "activemodel", ['>= 4.1', '< 6']
 end

--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -5,6 +5,7 @@ require 'active_support/concern'
 require 'active_support/time'
 
 require 'dry-types'
+require 'jsonapi_errorable'
 
 require 'jsonapi/serializable'
 # Temporary fix until fixed upstream
@@ -49,12 +50,14 @@ end
 
 require "jsonapi_compliable/version"
 require "jsonapi_compliable/configuration"
+require "jsonapi_compliable/context"
 require "jsonapi_compliable/errors"
 require "jsonapi_compliable/types"
 require "jsonapi_compliable/adapters/abstract"
 require "jsonapi_compliable/resource/sideloading"
 require "jsonapi_compliable/resource/configuration"
 require "jsonapi_compliable/resource/dsl"
+require "jsonapi_compliable/resource/interface"
 require "jsonapi_compliable/resource/polymorphism"
 require "jsonapi_compliable/sideload"
 require "jsonapi_compliable/sideload/has_many"
@@ -64,6 +67,7 @@ require "jsonapi_compliable/sideload/many_to_many"
 require "jsonapi_compliable/sideload/polymorphic_belongs_to"
 require "jsonapi_compliable/resource"
 require "jsonapi_compliable/resource_proxy"
+require "jsonapi_compliable/persistence_proxy"
 require "jsonapi_compliable/single_resource_proxy"
 require "jsonapi_compliable/query"
 require "jsonapi_compliable/scope"
@@ -102,6 +106,7 @@ end
 
 if defined?(Rails)
   require 'jsonapi_compliable/railtie'
+  require 'jsonapi_compliable/rails'
 end
 
 module JsonapiCompliable

--- a/lib/jsonapi_compliable/adapters/active_record/base.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/base.rb
@@ -74,13 +74,22 @@ module JsonapiCompliable
           }
         end
 
+        # TODO: maybe move to sideload classes
+        # associate(parent, child) does fire in SL
+        # TODO: many-to-many << should only fire when persisting (?)
         def associate(parent, child, association_name, association_type)
-          parent.association(association_name).loaded!
+          association = parent.association(association_name)
+          association.loaded!
 
           if [:has_many, :many_to_many].include?(association_type)
-            parent.association(association_name).target |= [child]
+            if association_type == :many_to_many &&
+                !parent.send(association_name).exists?(child.id)
+              parent.send(association_name) << child
+            else
+              association.target |= [child]
+            end
           else
-            parent.association(association_name).target = child
+            association.target = child
           end
         end
 

--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -5,97 +5,6 @@ module JsonapiCompliable
   module Base
     extend ActiveSupport::Concern
 
-    included do
-      class << self
-        attr_accessor :_jsonapi_compliable, :_sideload_whitelist
-      end
-
-      def self.inherited(klass)
-        super
-        klass._jsonapi_compliable = Class.new(_jsonapi_compliable)
-        klass._sideload_whitelist = _sideload_whitelist.dup if _sideload_whitelist
-      end
-    end
-
-    # @!classmethods
-    module ClassMethods
-      # Define your JSONAPI configuration
-      #
-      # @example Inline Resource
-      #   # 'Quick and Dirty' solution that does not require a separate
-      #   # Resource object
-      #   class PostsController < ApplicationController
-      #     jsonapi do
-      #       type :posts
-      #       use_adapter JsonapiCompliable::Adapters::ActiveRecord
-      #
-      #       allow_filter :title
-      #     end
-      #   end
-      #
-      # @example Resource Class (preferred)
-      #   # Make code reusable by encapsulating it in a Resource class
-      #   class PostsController < ApplicationController
-      #     jsonapi resource: PostResource
-      #   end
-      #
-      # @see Resource
-      # @param resource [Resource] the Resource class associated to this endpoint
-      # @return [void]
-      def jsonapi(foo = 'bar', resource: nil, &blk)
-        if resource
-          self._jsonapi_compliable = resource
-        else
-          if !self._jsonapi_compliable
-            self._jsonapi_compliable = Class.new(JsonapiCompliable::Resource)
-          end
-        end
-
-        self._jsonapi_compliable.class_eval(&blk) if blk
-      end
-
-      # Set the sideload whitelist. You may want to omit sideloads for
-      # security or performance reasons.
-      #
-      # Uses JSONAPI::IncludeDirective from {{http://jsonapi-rb.org jsonapi-rb}}
-      #
-      # @example Whitelisting Relationships
-      #   # Given the following whitelist
-      #   class PostsController < ApplicationResource
-      #     jsonapi resource: MyResource
-      #
-      #     sideload_whitelist({
-      #       index: [:blog],
-      #       show: [:blog, { comments: :author }]
-      #     })
-      #
-      #     # ... code ...
-      #   end
-      #
-      #   # A request to sideload 'tags'
-      #   #
-      #   # GET /posts/1?include=tags
-      #   #
-      #   # ...will silently fail.
-      #   #
-      #   # A request for comments and tags:
-      #   #
-      #   # GET /posts/1?include=tags,comments
-      #   #
-      #   # ...will only sideload comments
-      #
-      # @param [Hash, Array, Symbol] whitelist
-      # @see Query#include_hash
-      def sideload_whitelist(hash)
-        self._sideload_whitelist = JSONAPI::IncludeDirective.new(hash).to_hash
-      end
-    end
-
-    # @api private
-    def sideload_whitelist
-      self.class._sideload_whitelist || {}
-    end
-
     # Returns an instance of the associated Resource
     #
     # In other words, if you configured your controller as:
@@ -154,95 +63,22 @@ module JsonapiCompliable
       jsonapi_resource.build_scope(scope, query, opts)
     end
 
+    def normalized_params
+      normalized = params
+      if normalized.respond_to?(:to_unsafe_h)
+        normalized = normalized.to_unsafe_h.deep_symbolize_keys
+      end
+      normalized
+    end
+
     # @see Deserializer#initialize
     # @return [Deserializer]
     def deserialized_params
-      @deserialized_params ||= JsonapiCompliable::Deserializer.new(params, verb)
+      @deserialized_params ||= JsonapiCompliable::Deserializer.new(normalized_params)
     end
 
-    def verb
-      request.env['REQUEST_METHOD'].downcase.to_sym
-    end
-
-    # Create the resource model and process all nested relationships via the
-    # serialized parameters. Any error, including validation errors, will roll
-    # back the transaction.
-    #
-    # @example Basic Rails
-    #   # Example Resource must have 'model'
-    #   #
-    #   # class PostResource < ApplicationResource
-    #   #   model Post
-    #   # end
-    #   def create
-    #     post, success = jsonapi_create.to_a
-    #
-    #     if success
-    #       render_jsonapi(post, scope: false)
-    #     else
-    #       render_errors_for(post)
-    #     end
-    #   end
-    #
-    # @see Resource.model
-    # @see #resource
-    # @see #deserialized_params
-    # @return [Util::ValidationResponse]
-    def jsonapi_create
-      _persist do
-        jsonapi_resource.persist_with_relationships \
-          deserialized_params.meta,
-          deserialized_params.attributes,
-          deserialized_params.relationships
-      end
-    end
-
-    # Update the resource model and process all nested relationships via the
-    # serialized parameters. Any error, including validation errors, will roll
-    # back the transaction.
-    #
-    # @example Basic Rails
-    #   # Example Resource must have 'model'
-    #   #
-    #   # class PostResource < ApplicationResource
-    #   #   model Post
-    #   # end
-    #   def update
-    #     post, success = jsonapi_update.to_a
-    #
-    #     if success
-    #       render_jsonapi(post, scope: false)
-    #     else
-    #       render_errors_for(post)
-    #     end
-    #   end
-    #
-    # @see #jsonapi_create
-    # @return [Util::ValidationResponse]
-    def jsonapi_update
-      _persist do
-        jsonapi_resource.persist_with_relationships \
-          deserialized_params.meta,
-          deserialized_params.attributes,
-          deserialized_params.relationships
-      end
-    end
-
-    # Delete the model
-    # Any error, including validation errors, will roll back the transaction.
-    #
-    # Note: +before_commit+ hooks still run unless excluded
-    #
-    # @return [Util::ValidationResponse]
-    def jsonapi_destroy
-      jsonapi_resource.transaction do
-        model = jsonapi_resource.destroy(params[:id])
-        validator = ::JsonapiCompliable::Util::ValidationResponse.new \
-          model, deserialized_params
-        validator.validate!
-        jsonapi_resource.before_commit(model, :destroy)
-        validator
-      end
+    def persisting?
+      [:create, :update, :destroy].include?(JsonapiCompliable.context[:namespace])
     end
 
     def jsonapi_render_options
@@ -254,51 +90,21 @@ module JsonapiCompliable
       options
     end
 
+    def build
+      PersistenceProxy.new(jsonapi_resource, deserialized_params)
+    end
+
     def proxy(base = nil, opts = {})
-      base       ||= jsonapi_resource.base_scope
-      scope_opts   = opts.slice(:sideload_parent_length, :default_paginate, :after_resolve)
-      scope        = jsonapi_scope(base, scope_opts)
-      proxy_class  = !!opts[:single] ? SingleResourceProxy : ResourceProxy
-      proxy_class.new(jsonapi_resource, scope, query)
-    end
-
-    def render_jsonapi(proxy, options = {})
-      options = jsonapi_render_options.merge(options)
-      Renderer.new(proxy, options).to_jsonapi
-    end
-
-    # Define a hash that will be automatically merged into your
-    # render_jsonapi call
-    #
-    # @example
-    #   # this
-    #   render_jsonapi(foo)
-    #   # is equivalent to this
-    #   render jsonapi: foo, default_jsonapi_render_options
-    #
-    # @see #render_jsonapi
-    # @return [Hash] the options hash you define
-    def default_jsonapi_render_options
-      {}.tap do |options|
+      if persisting?
+        PersistenceProxy.new(jsonapi_resource, deserialized_params)
+      else
+        base       ||= jsonapi_resource.base_scope
+        scope_opts   = opts.slice(:sideload_parent_length, :default_paginate, :after_resolve)
+        scope = jsonapi_scope(base, scope_opts)
+        !!opts[:single] ? SingleResourceProxy : ResourceProxy
+        proxy_class  = !!opts[:single] ? SingleResourceProxy : ResourceProxy
+        proxy_class.new(jsonapi_resource, scope, query)
       end
-    end
-
-    private
-
-    def _persist
-      jsonapi_resource.transaction do
-        ::JsonapiCompliable::Util::Hooks.record do
-          model = yield
-          validator = ::JsonapiCompliable::Util::ValidationResponse.new \
-            model, deserialized_params
-          validator.validate!
-          validator
-        end
-      end
-    end
-
-    def force_includes?
-      not deserialized_params.data.nil?
     end
   end
 end

--- a/lib/jsonapi_compliable/context.rb
+++ b/lib/jsonapi_compliable/context.rb
@@ -1,0 +1,15 @@
+module JsonapiCompliable
+  module Context
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :_sideload_whitelist
+    end
+
+    class_methods do
+      def sideload_whitelist(hash)
+        self._sideload_whitelist = JSONAPI::IncludeDirective.new(hash).to_hash
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/deserializer.rb
+++ b/lib/jsonapi_compliable/deserializer.rb
@@ -45,12 +45,17 @@
 #
 #   { type: 'authors', method: :create, temp_id: 'abc123' }
 class JsonapiCompliable::Deserializer
-  # @param payload [Hash] The incoming payload with symbolized keys
-  # @param env [Hash] the Rack env (e.g. +request.env+).
-  def initialize(payload, verb)
+  def initialize(payload)
     @payload = payload
     @payload = @payload[:_jsonapi] if @payload.has_key?(:_jsonapi)
-    @verb = verb
+  end
+
+  def params
+    @payload
+  end
+
+  def action
+    JsonapiCompliable.context[:namespace]
   end
 
   # @return [Hash] the raw :data value of the payload
@@ -87,7 +92,7 @@ class JsonapiCompliable::Deserializer
     {
       type: data[:type],
       temp_id: data[:'temp-id'],
-      method: method
+      method: action
     }
   end
 
@@ -128,14 +133,6 @@ class JsonapiCompliable::Deserializer
 
   def included
     @payload[:included] || []
-  end
-
-  def method
-    case @verb
-      when :post then :create
-      when :put, :patch then :update
-      when :delete then :destroy
-    end
   end
 
   def removed?(relationship_payload)

--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -24,13 +24,15 @@ module JsonapiCompliable
           {
             sortable: 'sort on',
             filterable: 'filter on',
-            readable: 'read'
+            readable: 'read',
+            writable: 'write'
           }[@flag]
         else
           {
             sortable: 'add sort',
             filterable: 'add filter',
-            readable: 'read'
+            readable: 'read',
+            writable: 'write'
           }[@flag]
         end
       end
@@ -81,6 +83,63 @@ self.polymorphic = ['Subclass1Resource', 'Subclass2Resource']
 
       def initialize(validation_response)
         @validation_response = validation_response
+      end
+    end
+
+    class ImplicitFilterTypeMissing < Base
+      def initialize(resource_class, name)
+        @resource_class = resource_class
+        @name = name
+      end
+
+      def message
+        <<-MSG
+Tried to add filter-only attribute #{@name.inspect}, but type was missing!
+
+If you are adding a filter that does not have a corresponding attribute, you must pass a type:
+
+filter :name, :string do <--- like this
+  # ... code ...
+end
+        MSG
+      end
+    end
+
+    class ImplicitSortTypeMissing < Base
+      def initialize(resource_class, name)
+        @resource_class = resource_class
+        @name = name
+      end
+
+      def message
+        <<-MSG
+Tried to add sort-only attribute #{@name.inspect}, but type was missing!
+
+If you are adding a sort that does not have a corresponding attribute, you must pass a type:
+
+sort :name, :string do <--- like this
+  # ... code ...
+end
+        MSG
+      end
+    end
+
+    class TypecastFailed < Base
+      def initialize(resource, name, value, error)
+        @resource = resource
+        @name = name
+        @value = value
+        @error = error
+      end
+
+      def message
+        <<-MSG
+#{@resource.class}: Failed typecasting #{@name.inspect}! Given #{@value.inspect} but the following error was raised:
+
+#{@error.message}
+
+#{@error.backtrace.join("\n")}
+        MSG
       end
     end
 

--- a/lib/jsonapi_compliable/persistence_proxy.rb
+++ b/lib/jsonapi_compliable/persistence_proxy.rb
@@ -1,0 +1,81 @@
+module JsonapiCompliable
+  class PersistenceProxy
+    # Todo quack like same proxy (data, [], etc)
+    # Ideally could return unpersisted graph, then save
+    # then returns persisted graph
+
+    # Todo: eventually this will have @query as well, to support
+    # a POST to /posts?include=comments
+    attr_reader :resource, :payload
+
+    # ...todo scope?
+    def initialize(resource, payload)
+      @resource = resource
+      @payload = payload
+    end
+
+    # jsonapi_create
+    def save
+      persist do
+        @data = @resource.persist_with_relationships \
+          @payload.meta,
+          @payload.attributes,
+          @payload.relationships
+      end.to_a[1]
+    end
+
+    def jsonapi_render_options(opts = {})
+      opts[:meta]   ||= {}
+      opts[:expose] ||= {}
+      opts[:expose][:context] = JsonapiCompliable.context[:object]
+      opts
+    end
+
+    def to_jsonapi(options = {})
+      options = jsonapi_render_options(options)
+      Renderer.new(self, options).to_jsonapi
+    end
+
+    def update_attributes
+      save
+    end
+
+    def destroy
+      @resource.transaction do
+        model = @resource.destroy(@payload.params[:filter][:id])
+        model.instance_variable_set(:@__serializer_klass, @resource.serializer)
+        @data = model
+        validator = ::JsonapiCompliable::Util::ValidationResponse.new \
+          model, @payload
+        validator.validate!
+        @resource.before_commit(model, :destroy)
+        validator
+      end.to_a[1]
+    end
+
+    def errors
+      data.errors
+    end
+
+    def data
+      @data
+    end
+
+    # TODO
+    def stats
+      {}
+    end
+
+    def persist
+      @resource.transaction do
+        ::JsonapiCompliable::Util::Hooks.record do
+          model = yield
+          validator = ::JsonapiCompliable::Util::ValidationResponse.new \
+            model, @payload
+          validator.validate!
+          validator
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/query.rb
+++ b/lib/jsonapi_compliable/query.rb
@@ -139,7 +139,7 @@ module JsonapiCompliable
 
         whitelist = nil
         if @resource.context
-          whitelist = @resource.context.sideload_whitelist
+          whitelist = @resource.context._sideload_whitelist
           whitelist = whitelist[@resource.context_namespace] if whitelist
         end
 

--- a/lib/jsonapi_compliable/rails.rb
+++ b/lib/jsonapi_compliable/rails.rb
@@ -1,5 +1,3 @@
-require 'jsonapi/rails'
-
 module JsonapiCompliable
   # Rails Integration. Mix this in to ApplicationController.
   #
@@ -10,11 +8,21 @@ module JsonapiCompliable
   # @see Base#wrap_context
   module Rails
     def self.included(klass)
-      klass.send(:include, Base)
-
       klass.class_eval do
+        include JsonapiCompliable::Context
+        include JsonapiErrorable
         around_action :wrap_context
       end
+    end
+
+    def wrap_context
+      JsonapiCompliable.with_context(jsonapi_context, action_name.to_sym) do
+        yield
+      end
+    end
+
+    def jsonapi_context
+      self
     end
   end
 end

--- a/lib/jsonapi_compliable/renderer.rb
+++ b/lib/jsonapi_compliable/renderer.rb
@@ -16,10 +16,15 @@ module JsonapiCompliable
     def to_jsonapi
       notify do
         instance = JSONAPI::Serializable::Renderer.new
-        options[:fields] = proxy.query.fields
-        options[:expose][:extra_fields] = proxy.query.extra_fields
-        options[:include] = proxy.query.include_hash
-        options[:meta].merge!(stats: proxy.stats) unless proxy.stats.empty?
+
+        if proxy.is_a?(PersistenceProxy)
+          options[:include] = proxy.payload.include_directive
+        else
+          options[:fields] = proxy.query.fields
+          options[:expose][:extra_fields] = proxy.query.extra_fields
+          options[:include] = proxy.query.include_hash
+          options[:meta].merge!(stats: proxy.stats) unless proxy.stats.empty?
+        end
         instance.render(records, options).to_json
       end
     end

--- a/lib/jsonapi_compliable/resource/interface.rb
+++ b/lib/jsonapi_compliable/resource/interface.rb
@@ -1,0 +1,36 @@
+module JsonapiCompliable
+  class Resource
+    module Interface
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def all(params = {}, base_scope = nil)
+          _all(params, {}, base_scope)
+        end
+
+        def _all(params, opts, base_scope)
+          runner = Runner.new(self, params)
+          runner.proxy(base_scope, opts)
+        end
+
+        def find(params, base_scope = nil)
+          params[:filter] ||= {}
+          params[:filter].merge!(id: params.delete(:id))
+
+          runner = Runner.new(self, params)
+          runner.proxy(base_scope, single: true)
+        end
+
+        def build(params)
+          runner = Runner.new(self, params)
+          runner.build
+        end
+
+        def create(params)
+          runner = Runner.new(self, params)
+          runner.jsonapi_create
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/resource_proxy.rb
+++ b/lib/jsonapi_compliable/resource_proxy.rb
@@ -26,6 +26,18 @@ module JsonapiCompliable
       data[val]
     end
 
+    def jsonapi_render_options(opts = {})
+      opts[:meta]   ||= {}
+      opts[:expose] ||= {}
+      opts[:expose][:context] = JsonapiCompliable.context[:object]
+      opts
+    end
+
+    def to_jsonapi(options = {})
+      options = jsonapi_render_options(options)
+      Renderer.new(self, options).to_jsonapi
+    end
+
     def to_a
       records = @scope.resolve
       if records.empty? && raise_on_missing?

--- a/lib/jsonapi_compliable/runner.rb
+++ b/lib/jsonapi_compliable/runner.rb
@@ -1,14 +1,11 @@
 module JsonapiCompliable
   class Runner
-    attr_reader :params, :verb
+    attr_reader :params
     include JsonapiCompliable::Base
 
-    jsonapi resource: JsonapiCompliable::Resource
-
-    def initialize(resource_class, params, verb: :get)
+    def initialize(resource_class, params)
       @resource_class = resource_class
       @params = params
-      @verb = verb
     end
 
     def jsonapi_resource

--- a/lib/jsonapi_compliable/scoping/filter.rb
+++ b/lib/jsonapi_compliable/scoping/filter.rb
@@ -66,15 +66,15 @@ module JsonapiCompliable
     # return a single element instead of array
     def coerce_types(name, value)
       type_name = resource.all_attributes[name][:type]
-      type = Types[type_name][:params]
+      cast = ->(value) { @resource.typecast(name, value, :filterable) }
       if value.is_a?(Array)
         if type_name.to_s.starts_with?('array')
-          type[value]
+          cast.call(value)
         else
-          value.map { |v| type[v] }
+          value.map { |v| cast.call(v) }
         end
       else
-        type[value]
+        cast.call(value)
       end
     end
   end

--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -66,6 +66,10 @@ module JsonapiCompliable
       !!@writable
     end
 
+    def polymorphic_parent?
+      resource.polymorphic?
+    end
+
     def polymorphic_child?
       !!@polymorphic_child
     end
@@ -188,17 +192,21 @@ module JsonapiCompliable
       end
     end
 
-    def self.fire_hooks!(parent, objects, method)
-      return unless self.hooks
+    def fire_hooks!(parent, objects, method)
+      return unless self.class.hooks
 
-      hooks = self.hooks[:"after_#{method}"] + self.hooks[:after_save]
-      hooks.compact.each do |hook|
+      all = self.class.hooks[:"after_#{method}"] + self.class.hooks[:after_save]
+      all.compact.each do |hook|
         resource.instance_exec(parent, objects, &hook)
       end
     end
 
     def associate(parent, child)
       parent_resource.associate(parent, child, association_name, type)
+    end
+
+    def disassociate(parent, child)
+      parent_resource.disassociate(parent, child, association_name, type)
     end
 
     private
@@ -211,11 +219,6 @@ module JsonapiCompliable
           fire_assign(parents, results)
         }
       end
-    end
-
-
-    def disassociate(parent, child)
-      parent_resource.disassociate(parent, child, association_name, type)
     end
 
     def fire_assign_each(parent, children)

--- a/lib/jsonapi_compliable/sideload/polymorphic_belongs_to.rb
+++ b/lib/jsonapi_compliable/sideload/polymorphic_belongs_to.rb
@@ -70,6 +70,12 @@ class JsonapiCompliable::Sideload::PolymorphicBelongsTo < JsonapiCompliable::Sid
     grouper.apply(self, parent_resource_class)
   end
 
+  def child_for_type(type)
+    children.values.find do |sideload|
+      sideload.resource.type == type
+    end
+  end
+
   def resolve(parents, query)
     parents.group_by(&grouper.column_name).each_pair do |group_name, group|
       next if group_name.nil?

--- a/lib/jsonapi_compliable/single_resource_proxy.rb
+++ b/lib/jsonapi_compliable/single_resource_proxy.rb
@@ -6,6 +6,18 @@ module JsonapiCompliable
       record
     end
 
+    def jsonapi_render_options(opts = {})
+      opts[:meta]   ||= {}
+      opts[:expose] ||= {}
+      opts[:expose][:context] = JsonapiCompliable.context[:object]
+      opts
+    end
+
+    def to_jsonapi(options = {})
+      options = jsonapi_render_options(options)
+      Renderer.new(self, options).to_jsonapi
+    end
+
     def record
       data
     end

--- a/lib/jsonapi_compliable/types.rb
+++ b/lib/jsonapi_compliable/types.rb
@@ -64,54 +64,62 @@ module JsonapiCompliable
       Dry::Types['params.hash'][input].deep_symbolize_keys
     end
 
-    # Todo: add array_of_whatever by default
     def self.map
       @map ||= begin
         hash = {
           string: {
             params: Dry::Types['coercible.string'],
             read: Dry::Types['coercible.string'],
-            test: Dry::Types['strict.string']
+            test: Dry::Types['strict.string'],
+            write: Dry::Types['coercible.string']
           },
           integer: {
             params: PresentInteger,
             read: Integer,
-            test: Dry::Types['strict.integer']
+            test: Dry::Types['strict.integer'],
+            write: Integer
           },
           decimal: {
             params: ParamDecimal,
             read: Dry::Types['json.decimal'],
-            test: Dry::Types['strict.string']
+            test: Dry::Types['strict.string'],
+            write: Dry::Types['json.decimal']
           },
           float: {
             params: Dry::Types['coercible.float'],
             read: Float,
-            test: Dry::Types['strict.float']
+            test: Dry::Types['strict.float'],
+            write: Float
           },
           boolean: {
             params: PresentBool,
             read: Bool,
-            test: Dry::Types['strict.bool']
+            test: Dry::Types['strict.bool'],
+            write: Bool
           },
           date: {
             params: PresentDate,
             read: Date,
-            test: Dry::Types['strict.string']
+            test: Dry::Types['strict.string'],
+            write: Date
           },
           datetime: {
             params: PresentParamsDateTime,
             read: DateTime,
-            test: Dry::Types['strict.string']
+            test: Dry::Types['strict.string'],
+            write: DateTime
           },
           hash: {
             params: PresentParamsHash,
             read: Dry::Types['strict.hash'],
-            test: Dry::Types['strict.hash']
+            test: Dry::Types['strict.hash'],
+            write: Dry::Types['strict.hash']
           },
           array: {
             params: Dry::Types['strict.array'],
             read: Dry::Types['strict.array'],
-            test: Dry::Types['strict.array']
+            test: Dry::Types['strict.array'],
+            write: Dry::Types['strict.array']
           }
         }
 
@@ -120,7 +128,8 @@ module JsonapiCompliable
           arrays[:"array_of_#{name.to_s.pluralize}"] = {
             params: Dry::Types['strict.array'].of(map[:params]),
             read: Dry::Types['strict.array'].of(map[:read]),
-            test: Dry::Types['strict.array'].of(map[:test])
+            test: Dry::Types['strict.array'].of(map[:test]),
+            write: Dry::Types['strict.array'].of(map[:write])
           }
         end
         hash.merge!(arrays)

--- a/lib/jsonapi_compliable/util/attribute_check.rb
+++ b/lib/jsonapi_compliable/util/attribute_check.rb
@@ -10,7 +10,7 @@ module JsonapiCompliable
 
       def initialize(resource, name, flag, request, raise_error)
         @resource = resource
-        @name = name
+        @name = name.to_sym
         @flag = flag
         @request = request
         @raise_error = raise_error
@@ -37,9 +37,10 @@ module JsonapiCompliable
       end
 
       def maybe_raise(opts = {})
-        if raise_error?
-          default = { request: request, exists: true }
-          raise error_class.new(resource, name, flag, default.merge(opts))
+        default = { request: request, exists: true }
+        opts = default.merge(opts)
+        if raise_error?(opts[:exists])
+          raise error_class.new(resource, name, flag, opts)
         else
           false
         end
@@ -71,8 +72,12 @@ module JsonapiCompliable
         !!attribute
       end
 
-      def raise_error?
-        !!raise_error
+      def raise_error?(exists)
+        if raise_error == :only_unsupported
+          exists ? true : false
+        else
+          !!raise_error
+        end
       end
 
       def request?

--- a/lib/jsonapi_compliable/util/relationship_payload.rb
+++ b/lib/jsonapi_compliable/util/relationship_payload.rb
@@ -43,15 +43,15 @@ module JsonapiCompliable
       end
 
       def payload_for(sideload, relationship_payload)
-        if sideload.polymorphic?
+        if sideload.polymorphic_parent?
           type     = relationship_payload[:meta][:jsonapi_type]
-          sideload = sideload.polymorphic_child_for_type(type)
+          sideload = sideload.child_for_type(type.to_sym)
         end
         relationship_payload[:meta][:method] ||= :update
 
         {
           sideload: sideload,
-          is_polymorphic: !sideload.parent.nil?,
+          is_polymorphic: sideload.polymorphic_child?,
           primary_key: sideload.primary_key,
           foreign_key: sideload.foreign_key,
           attributes: relationship_payload[:attributes],

--- a/lib/jsonapi_compliable/util/serializer_attributes.rb
+++ b/lib/jsonapi_compliable/util/serializer_attributes.rb
@@ -60,9 +60,9 @@ module JsonapiCompliable
       def default_proc
         type_name = @attr[:type]
         _name = @name
+        _resource = @resource.new
         ->(_) {
-          type = JsonapiCompliable::Types[type_name]
-          type[:read][@object.send(_name)]
+          _resource.typecast(_name, @object.send(_name), :readable)
         }
       end
 

--- a/spec/deserializer_spec.rb
+++ b/spec/deserializer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe JsonapiCompliable::Deserializer do
     }
   end
 
-  let(:instance) { described_class.new(payload, {}) }
+  let(:instance) { described_class.new(payload) }
 
   describe '#attributes' do
     subject { instance.attributes }

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -65,52 +65,52 @@ class ApplicationRecord < ActiveRecord::Base
   end
 end
 
-#class Classification < ApplicationRecord
+class Classification < ApplicationRecord
   #has_many :employees
   #validates :description, presence: true
-#end
+end
 
-#class Team < ApplicationRecord
-  #has_many :employee_teams
-  #has_many :employees, through: :employee_teams
-#end
+class Team < ApplicationRecord
+  has_many :employee_teams
+  has_many :employees, through: :employee_teams
+end
 
-#class EmployeeTeam < ApplicationRecord
-  #belongs_to :team
-  #belongs_to :employee
-#end
+class EmployeeTeam < ApplicationRecord
+  belongs_to :team
+  belongs_to :employee
+end
 
-#class Office < ApplicationRecord
-  #has_many :employees, as: :workspace
-#end
+class Office < ApplicationRecord
+  has_many :employees, as: :workspace
+end
 
-#class HomeOffice < ApplicationRecord
-  #has_many :employees, as: :workspace
-#end
+class HomeOffice < ApplicationRecord
+  has_many :employees, as: :workspace
+end
 
 class Employee < ApplicationRecord
-  #belongs_to :workspace, polymorphic: true
-  #belongs_to :classification
+  belongs_to :workspace, polymorphic: true
+  belongs_to :classification
   has_many :positions
-  #validates :first_name, presence: true
-  #validates :delete_confirmation,
-    #presence: true,
-    #on: :destroy
+  validates :first_name, presence: true
+  validates :delete_confirmation,
+    presence: true,
+    on: :destroy
 
-  #has_many :employee_teams
-  #has_many :teams, through: :employee_teams
+  has_many :employee_teams
+  has_many :teams, through: :employee_teams
 
-  #has_one :salary
+  has_one :salary
 
-  #before_destroy do
-    #add_validation_error if force_validation_error
+  before_destroy do
+    add_validation_error if force_validation_error
 
-    #if Rails::VERSION::MAJOR >= 5
-      #throw(:abort) if errors.present?
-    #else
-      #errors.blank?
-    #end
-  #end
+    if Rails::VERSION::MAJOR >= 5
+      throw(:abort) if errors.present?
+    else
+      errors.blank?
+    end
+  end
 end
 
 class Position < ApplicationRecord
@@ -122,138 +122,58 @@ class Department < ApplicationRecord
   has_many :positions
 end
 
-#class Salary < ApplicationRecord
-  #belongs_to :employee
-#end
+class Salary < ApplicationRecord
+end
 
 class ApplicationResource < JsonapiCompliable::Resource
   self.adapter = JsonapiCompliable::Adapters::ActiveRecord::Base.new
   self.abstract_class = true
 end
 
-#class ClassificationResource < ApplicationResource
-  #type :classifications
-  #model Classification
-#end
-
-#class TeamResource < ApplicationResource
-  #type :teams
-  #model Team
-#end
-
-#class DepartmentResource < ApplicationResource
-  #type :departments
-  #model Department
-#end
-
-#class PositionResource < ApplicationResource
-  #type :positions
-  #model Position
-
-  #belongs_to :department,
-    #scope: -> { Department.all },
-    #foreign_key: :department_id,
-    #resource: DepartmentResource
-#end
-
-#class OfficeResource < ApplicationResource
-  #type :offices
-  #model Office
-#end
-
-#class HomeOfficeResource < ApplicationResource
-  #type :home_offices
-  #model HomeOffice
-#end
-
-#class SalaryResource < ApplicationResource
-  #type :salaries
-  #model Salary
-#end
-#
-class ApplicationSerializer < JSONAPI::Serializable::Resource
+class ClassificationResource < ApplicationResource
 end
 
-class SerializableEmployee < ApplicationSerializer
-  #type :employees
-
-  #attribute :first_name
-  #attribute :last_name
-  #attribute :age
-
-  #belongs_to :classification
-  # TODO MAKE SURE USES RESOURCE CLASS
-  has_many :positions
-  #has_many :teams
-
-  #has_one :salary
+class TeamResource < ApplicationResource
+  attribute :name, :string
 end
 
-class PositionSerializer < ApplicationSerializer
-  belongs_to :employee
+class DepartmentResource < ApplicationResource
+  attribute :name, :string
+end
+
+class PositionResource < ApplicationResource
+  attribute :employee_id, :integer, only: [:writable]
+  attribute :title, :string
   belongs_to :department
 end
 
-class DepartmentSerializer < ApplicationSerializer
-  has_many :positions
+class OfficeResource < ApplicationResource
+  attribute :address, :string
+end
+
+class HomeOfficeResource < ApplicationResource
+  attribute :address, :string
+end
+
+class SalaryResource < ApplicationResource
+  attribute :employee_id, :integer, only: [:writable]
+  attribute :base_rate, :float
+  attribute :overtime_rate, :float
 end
 
 class EmployeeResource < ApplicationResource
-  self.type = :employees
-  self.model = Employee
-  self.serializer = SerializableEmployee
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
 
-  #belongs_to :classification,
-    #scope: -> { Classification.all },
-    #foreign_key: :classification_id,
-    #resource: ClassificationResource
-  #has_many :positions,
-    #base_scope: -> { Position.all },
-    #foreign_key: :employee_id,
-    #resource: PositionResource
-  #has_and_belongs_to_many :teams,
-    #resource: TeamResource,
-    #scope: -> { Team.all },
-    #foreign_key: { employee_teams: :employee_id }
-  #has_one :salary,
-    #resource: SalaryResource,
-    #scope: -> { Salary.all },
-    #foreign_key: :employee_id
-
-  #polymorphic_belongs_to :workspace,
-    #group_by: :workspace_type,
-    #groups: {
-      #'Office' => {
-        #scope: -> { Office.all },
-        #resource: OfficeResource,
-        #foreign_key: :workspace_id
-      #},
-      #'HomeOffice' => {
-        #scope: -> { HomeOffice.all },
-        #resource: HomeOfficeResource,
-        #foreign_key: :workspace_id
-      #}
-    #}
+  has_many :positions
+  has_one :salary
+  belongs_to :classification
+  many_to_many :teams
+  polymorphic_belongs_to :workspace do
+    group_by(:workspace_type) do
+      on(:Office)
+      on(:HomeOffice)
+    end
+  end
 end
-
-
-#class SerializableClassification < SerializableAbstract
-  #type 'classifications'
-
-  #attribute :description
-#end
-
-#class SerializableTeam < SerializableAbstract
-  #type 'teams'
-
-  #attribute :name
-#end
-
-
-
-#class SerializableSalary < SerializableAbstract
-  #type 'salaries'
-
-  #attribute :base_rate
-  #attribute :overtime_rate
-#end

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -7,6 +7,7 @@ module PORO
             employees: [],
             positions: [],
             departments: [],
+            classifications: [],
             bios: [],
             team_memberships: [],
             teams: [],
@@ -27,6 +28,7 @@ module PORO
           employees: PORO::Employee,
           positions: PORO::Position,
           departments: PORO::Department,
+          classifications: PORO::Classification,
           bios: PORO::Bio,
           teams: PORO::Team,
           visas: PORO::Visa,
@@ -94,13 +96,19 @@ module PORO
   end
 
   class Base
+    include ActiveModel::Validations
     attr_accessor :id
 
     def self.create(attrs = {})
-      id = attrs[:id] || DB.data[type].length + 1
-      attrs = { id: id }.merge(attrs)
-      DB.data[type] << attrs
-      new(attrs)
+      if (record = new(attrs)).valid?
+        id = attrs[:id] || DB.data[type].length + 1
+        attrs.merge!(id: id)
+        record.id = id
+        DB.data[type] << attrs
+        record
+      else
+        record
+      end
     end
 
     def self.type
@@ -125,6 +133,8 @@ module PORO
       :positions,
       :bio,
       :teams,
+      :classification,
+      :classification_id,
       :credit_card,
       :credit_card_id,
       :cc_id,
@@ -144,6 +154,10 @@ module PORO
       :employee,
       :department_id,
       :department
+  end
+
+  class Classification < Base
+    attr_accessor :description
   end
 
   class Department < Base
@@ -224,6 +238,10 @@ module PORO
       "poro_minimum_#{attr}"
     end
 
+    def create(model, attributes)
+      model.create(attributes)
+    end
+
     def resolve(scope)
       ::PORO::DB.all(scope)
     end
@@ -264,6 +282,9 @@ module PORO
   end
 
   class PositionResource < ApplicationResource
+  end
+
+  class ClassificationResource < ApplicationResource
   end
 
   class DepartmentResource < ApplicationResource

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -446,22 +446,5 @@ if ENV['APPRAISAL_INITIALIZED']
         expect(json_includes('states').length).to eq(1)
       end
     end
-
-    context 'when overriding the resource' do
-      before do
-        controller.class_eval do
-          jsonapi resource: Legacy::AuthorResource do
-            paginate do |scope, current_page, per_page|
-              scope.limit(1)
-            end
-          end
-        end
-      end
-
-      it 'respects the override' do
-        get :index
-        expect(json_ids.length).to eq(1)
-      end
-    end
   end
 end

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -2,48 +2,38 @@ if ENV["APPRAISAL_INITIALIZED"]
   RSpec.describe 'persistence', type: :controller do
     include JsonHelpers
 
+    # todo ?include=foo
     controller(ApplicationController) do
-      jsonapi resource: EmployeeResource
-
-      # Avoid strong params / strong resource for this test
-      def params
-        @params ||= begin
-          hash = super.to_unsafe_h.with_indifferent_access
-          hash = hash[:params] if hash.has_key?(:params)
-          hash
-        end
-      end
-
       def create
-        employee, success = jsonapi_create.to_a
+        employee = EmployeeResource.build(params)
 
-        if success
-          render_jsonapi(employee, scope: false)
+        if employee.save
+          render jsonapi: employee
         else
           render json: {
             errors: {
               employee: employee.errors,
-              positions: employee.positions.map(&:errors),
-              departments: employee.positions.map(&:department).map(&:errors)
+              positions: employee.data.positions.map(&:errors),
+              departments: employee.data.positions.map(&:department).map(&:errors)
             }
           }
         end
       end
 
       def update
-        employee, success = jsonapi_update.to_a
+        employee = EmployeeResource.find(params)
 
-        if success
-          render_jsonapi(employee, scope: false)
+        if employee.update_attributes
+          render jsonapi: employee
         else
           render json: { error: employee.errors }
         end
       end
 
       def destroy
-        employee, success = jsonapi_destroy.to_a
+        employee = EmployeeResource.find(params)
 
-        if success
+        if employee.destroy
           render json: { meta: {} }
         else
           render json: { error: employee.errors }
@@ -91,6 +81,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       it 'responds with the persisted data' do
         do_post
         expect(json_item['id']).to eq(Employee.first.id.to_s)
+        expect(json_item['first_name']).to eq('Joe')
       end
 
       context 'when validation error' do
@@ -324,132 +315,6 @@ if ENV["APPRAISAL_INITIALIZED"]
             expect(salary.employee_id).to be_nil
           end
         end
-      end
-    end
-
-    describe 'has_and_belongs_to_many nested relationship' do
-      let(:employee) { Employee.create!(first_name: 'Joe') }
-      let(:prior_team) { Team.new(name: 'prior') }
-      let(:disassociate_team) { Team.new(name: 'disassociate') }
-      let(:destroy_team) { Team.new(name: 'destroy') }
-      let(:associate_team) { Team.create!(name: 'preexisting') }
-
-      before do
-        employee.teams << prior_team
-        employee.teams << disassociate_team
-        employee.teams << destroy_team
-      end
-
-      let(:payload) do
-        {
-          data: {
-            id: employee.id,
-            type: 'employees',
-            relationships: {
-              teams: {
-                data: [
-                  { :'temp-id' => 'abc123', type: 'teams', method: 'create' },
-                  { id: prior_team.id.to_s, type: 'teams', method: 'update' },
-                  { id: disassociate_team.id.to_s, type: 'teams', method: 'disassociate' },
-                  { id: destroy_team.id.to_s, type: 'teams', method: 'destroy' },
-                  { id: associate_team.id.to_s, type: 'teams', method: 'update' }
-                ]
-              }
-            }
-          },
-          included: [
-            {
-              :'temp-id' => 'abc123',
-              type: 'teams',
-              attributes: { name: 'Team #1' }
-            },
-            {
-              id: prior_team.id.to_s,
-              type: 'teams',
-              attributes: { name: 'Updated!' }
-            },
-            {
-              id: associate_team.id.to_s,
-              type: 'teams'
-            }
-          ]
-        }
-      end
-
-      it 'can create/update/disassociate/associate/destroy' do
-        expect(employee.teams).to include(destroy_team)
-        expect(employee.teams).to include(disassociate_team)
-        do_put(employee.id)
-
-        # Should properly delete/create from the through table
-        combos = EmployeeTeam.all.map { |et| [et.employee_id, et.team_id] }
-        expect(combos.uniq.length).to eq(combos.length)
-
-        employee.reload
-        expect(employee.teams).to_not include(disassociate_team)
-        expect(employee.teams).to_not include(destroy_team)
-        expect { disassociate_team.reload }.to_not raise_error
-        expect { destroy_team.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(prior_team.reload.name).to include('Updated!')
-        expect(employee.teams).to include(associate_team)
-        expect((employee.teams - [prior_team, associate_team]).first.name)
-          .to eq('Team #1')
-      end
-    end
-
-    describe 'nested polymorphic relationship' do
-      let(:workspace_type) { 'offices' }
-
-      let(:payload) do
-        {
-          data: {
-            type: 'employees',
-            attributes: { first_name: 'Joe' },
-            relationships: {
-              workspace: {
-                data: {
-                  :'temp-id' => 'work1', type: workspace_type, method: 'create'
-                }
-              }
-            }
-          },
-          included: [
-            {
-              type: workspace_type,
-              :'temp-id' => 'work1',
-              attributes: {
-                address: 'Fake Workspace Address'
-              }
-            }
-          ]
-        }
-      end
-
-      context 'with jsonapi type "offices"' do
-        it 'associates workspace as office' do
-          do_post
-          employee = Employee.first
-          expect(employee.workspace).to be_a(Office)
-        end
-      end
-
-      context 'with jsonapi type "home_offices"' do
-        let(:workspace_type) { 'home_offices' }
-
-        it 'associates workspace as home office' do
-          do_post
-          employee = Employee.first
-          expect(employee.workspace).to be_a(HomeOffice)
-        end
-      end
-
-      it 'saves the relationship correctly' do
-        expect {
-          do_post
-        }.to change { Employee.count }.by(1)
-        employee = Employee.first
-        workspace = employee.workspace
-        expect(workspace.address).to eq('Fake Workspace Address')
       end
     end
 
@@ -771,6 +636,132 @@ if ENV["APPRAISAL_INITIALIZED"]
             'departments' => [{ 'base' => ['Forced validation error'] }]
           }
         })
+      end
+    end
+
+    describe 'has_and_belongs_to_many nested relationship' do
+      let(:employee) { Employee.create!(first_name: 'Joe') }
+      let(:prior_team) { Team.new(name: 'prior') }
+      let(:disassociate_team) { Team.new(name: 'disassociate') }
+      let(:destroy_team) { Team.new(name: 'destroy') }
+      let(:associate_team) { Team.create!(name: 'preexisting') }
+
+      before do
+        employee.teams << prior_team
+        employee.teams << disassociate_team
+        employee.teams << destroy_team
+      end
+
+      let(:payload) do
+        {
+          data: {
+            id: employee.id,
+            type: 'employees',
+            relationships: {
+              teams: {
+                data: [
+                  { :'temp-id' => 'abc123', type: 'teams', method: 'create' },
+                  { id: prior_team.id.to_s, type: 'teams', method: 'update' },
+                  { id: disassociate_team.id.to_s, type: 'teams', method: 'disassociate' },
+                  { id: destroy_team.id.to_s, type: 'teams', method: 'destroy' },
+                  { id: associate_team.id.to_s, type: 'teams', method: 'update' }
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              :'temp-id' => 'abc123',
+              type: 'teams',
+              attributes: { name: 'Team #1' }
+            },
+            {
+              id: prior_team.id.to_s,
+              type: 'teams',
+              attributes: { name: 'Updated!' }
+            },
+            {
+              id: associate_team.id.to_s,
+              type: 'teams'
+            }
+          ]
+        }
+      end
+
+      it 'can create/update/disassociate/associate/destroy' do
+        expect(employee.teams).to include(destroy_team)
+        expect(employee.teams).to include(disassociate_team)
+        do_put(employee.id)
+
+        # Should properly delete/create from the through table
+        combos = EmployeeTeam.all.map { |et| [et.employee_id, et.team_id] }
+        expect(combos.uniq.length).to eq(combos.length)
+
+        employee.reload
+        expect(employee.teams).to_not include(disassociate_team)
+        expect(employee.teams).to_not include(destroy_team)
+        expect { disassociate_team.reload }.to_not raise_error
+        expect { destroy_team.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(prior_team.reload.name).to include('Updated!')
+        expect(employee.teams).to include(associate_team)
+        expect((employee.teams - [prior_team, associate_team]).first.name)
+          .to eq('Team #1')
+      end
+    end
+
+    describe 'nested polymorphic relationship' do
+      let(:workspace_type) { 'offices' }
+
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Joe' },
+            relationships: {
+              workspace: {
+                data: {
+                  :'temp-id' => 'work1', type: workspace_type, method: 'create'
+                }
+              }
+            }
+          },
+          included: [
+            {
+              type: workspace_type,
+              :'temp-id' => 'work1',
+              attributes: {
+                address: 'Fake Workspace Address'
+              }
+            }
+          ]
+        }
+      end
+
+      context 'with jsonapi type "offices"' do
+        it 'associates workspace as office' do
+          do_post
+          employee = Employee.first
+          expect(employee.workspace).to be_a(Office)
+        end
+      end
+
+      context 'with jsonapi type "home_offices"' do
+        let(:workspace_type) { 'home_offices' }
+
+        it 'associates workspace as home office' do
+          do_post
+          employee = Employee.first
+          expect(employee.workspace).to be_a(HomeOffice)
+        end
+      end
+
+      it 'saves the relationship correctly' do
+        expect {
+          do_post
+        }.to change { Employee.count }.by(1)
+        employee = Employee.first
+        workspace = employee.workspace
+        expect(workspace.address).to eq('Fake Workspace Address')
       end
     end
   end

--- a/spec/jsonapi_compliable_spec.rb
+++ b/spec/jsonapi_compliable_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe JsonapiCompliable do
       attr_accessor :params
       include JsonapiCompliable::Base
 
-      jsonapi resource: PORO::EmployeeResource
-
       def jsonapi_resource
         PORO::EmployeeResource.new
       end
@@ -19,29 +17,6 @@ RSpec.describe JsonapiCompliable do
   end
 
   let(:instance) { klass.new }
-
-  describe '.jsonapi' do
-    let(:subclass1) do
-      Class.new(klass)
-    end
-
-    let(:subclass2) do
-      Class.new(subclass1) do
-        jsonapi resource: PORO::PositionResource
-      end
-    end
-
-    context 'when subclassing and customizing' do
-      it 'preserves values from superclass' do
-        expect(subclass1._jsonapi_compliable.type).to eq(:employees)
-      end
-
-      it 'can override in subclass' do
-        expect(subclass1._jsonapi_compliable.type).to eq(:employees)
-        expect(subclass2._jsonapi_compliable.type).to eq(:positions)
-      end
-    end
-  end
 
   describe '#wrap_context' do
     before do
@@ -80,37 +55,6 @@ RSpec.describe JsonapiCompliable do
       expect(proxy.query).to be_a(JsonapiCompliable::Query)
       expect(proxy.to_a).to eq('resolved')
       expect(proxy.stats).to eq('stats')
-    end
-  end
-
-  describe '#render_jsonapi' do
-    it 'is able to override options' do
-      proxy = double(data: [], stats: {}).as_null_object
-      json = instance.render_jsonapi(proxy, {
-        meta: { foo: 'bar' }
-      })
-      hash = JSON.parse(json)
-      expect(hash['meta']).to eq('foo' => 'bar')
-    end
-
-    context 'when passing apply_scoping: false' do
-      it 'does not appy jsonapi_scope' do
-        proxy = double(data: [], stats: {}).as_null_object
-        expect(PORO::DB).to_not receive(:all)
-        instance.render_jsonapi(proxy, apply_scoping: false)
-      end
-    end
-
-    context 'when passing manual :include' do
-      it 'respects the :include option' do
-        proxy = double(data: [], stats: {}).as_null_object
-        expect(JsonapiCompliable::Renderer).to receive(:new)
-          .with(anything, hash_including(include: { foo: {}}))
-          .and_call_original
-        instance.render_jsonapi(proxy, {
-          include: { foo: {} }, apply_scoping: false
-        })
-      end
     end
   end
 end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -1,0 +1,873 @@
+require 'spec_helper'
+
+# TODO: update
+RSpec.describe 'persistence' do
+  let(:payload) do
+    {
+      data: {
+        type: 'employees',
+        attributes: { first_name: 'Jane' }
+      }
+    }
+  end
+  let(:klass) do
+    Class.new(PORO::EmployeeResource) do
+      self.model = PORO::Employee
+
+      def self.name
+        'PORO::EmployeeResource'
+      end
+    end
+  end
+
+  around do |e|
+    JsonapiCompliable.with_context({}, :create) do
+      e.run
+    end
+  end
+
+  it 'can persist single entities' do
+    employee = klass.build(payload)
+    expect(employee.save).to eq(true)
+    expect(employee.data.id).to_not be_nil
+    expect(employee.data.first_name).to eq('Jane')
+  end
+
+  context 'when given an attribute that does not exist' do
+    before do
+      payload[:data][:attributes] = { foo: 'bar' }
+    end
+
+    it 'raises appropriate error' do
+      employee = klass.build(payload)
+      expect {
+        employee.save
+      }.to raise_error(JsonapiCompliable::Errors::AttributeError, 'PORO::EmployeeResource: Tried to write attribute :foo, but could not find an attribute with that name.')
+    end
+  end
+
+  context 'when given an attribute that is not writable' do
+    before do
+      klass.attribute :foo, :string, writable: false
+      payload[:data][:attributes] = { foo: 'bar' }
+    end
+
+    it 'raises appropriate error' do
+      employee = klass.build(payload)
+      expect {
+        employee.save
+      }.to raise_error(JsonapiCompliable::Errors::AttributeError, 'PORO::EmployeeResource: Tried to write attribute :foo, but the attribute was marked :writable => false.')
+    end
+  end
+
+  context 'when given a writable attribute of the wrong type' do
+    before do
+      klass.attribute :foo, :integer
+      payload[:data][:attributes] = { foo: 'bar' }
+    end
+
+    it 'raises helpful error' do
+      employee = klass.build(payload)
+      expect {
+        employee.save
+      }.to raise_error(JsonapiCompliable::Errors::TypecastFailed, /Failed typecasting :foo! Given "bar" but the following error was raised/)
+    end
+
+    context 'and it can coerce' do
+      before do
+        payload[:data][:attributes] = { first_name: 1 }
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        expect(employee.data.first_name).to eq('1')
+      end
+    end
+  end
+
+  describe 'types' do
+    def save(value)
+      payload[:data][:attributes][:age] = value
+      employee = klass.build(payload)
+      employee.save
+      employee.data.age
+    end
+
+    context 'when string' do
+      let!(:value) { 1 }
+
+      before do
+        klass.attribute :age, :string
+      end
+
+      it 'coerces' do
+        expect(save(1)).to eq('1')
+      end
+    end
+
+    context 'when integer' do
+      before do
+        klass.attribute :age, :integer
+      end
+
+      it 'coerces strings' do
+        expect(save('1')).to eq(1)
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      it 'does not coerce blank string to 0' do
+        expect {
+          save('')
+        }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when decimal' do
+      before do
+        klass.attribute :age, :decimal
+      end
+
+      it 'coerces integers' do
+        expect(save(1)).to eq(BigDecimal(1))
+      end
+
+      it 'coerces strings' do
+        expect(save('1')).to eq(BigDecimal(1))
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when float' do
+      before do
+        klass.attribute :age, :float
+      end
+
+      it 'coerces strings' do
+        expect(save('1.1')).to eq(1.1)
+      end
+
+      it 'coerces integers' do
+        expect(save(1)).to eq(1.0)
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when boolean' do
+      before do
+        klass.attribute :age, :boolean
+      end
+
+      it 'coerces strings' do
+        expect(save('true')).to eq(true)
+      end
+
+      it 'coerces integers' do
+        expect(save(1)).to eq(true)
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when date' do
+      before do
+        klass.attribute :age, :date
+      end
+
+      it 'coerces Date strings to correct format' do
+        expect(save('2018/01/06')).to eq(Date.parse('2018-01-06'))
+      end
+
+      it 'coerces Time strings to correct format' do
+        time = Time.parse('2018/01/06 4:36pm EST')
+        expect(save(time.iso8601)).to eq(Date.parse('2018-01-06'))
+      end
+
+      it 'coerces Time to correct date format' do
+        time = Time.parse('2018/01/06 4:36pm EST')
+        expect(save(time)).to eq(Date.parse('2018-01-06'))
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      context 'when only month' do
+        it 'defaults to first of the month' do
+          expect(save('2018/01')).to eq(Date.parse('2018-01-01'))
+        end
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when datetime' do
+      before do
+        klass.attribute :age, :datetime
+      end
+
+      it 'coerces Time correctly' do
+        time = Time.parse('2018-01-06 4:36pm PST')
+        expect(save(time)).to eq(DateTime.parse('2018-01-06 4:36pm PST'))
+      end
+
+      it 'coerces Date correctly' do
+        date = Date.parse('2018-01-06')
+        expect(save(date)).to eq(DateTime.parse('2018-01-06'))
+      end
+
+      it 'coerces date strings correctly' do
+        expect(save('2018-01-06')).to eq(DateTime.parse('2018-01-06'))
+      end
+
+      it 'preserves date string zones' do
+        result = save('2018-01-06 4:36pm PST')
+        expect(result.zone).to eq('-08:00')
+      end
+
+      it 'coerces time strings correctly' do
+        str = '2018-01-06 4:36pm PST'
+        time = Time.parse(str)
+        expect(save(time.iso8601)).to eq(DateTime.parse(str))
+      end
+
+      it 'preserves time string zones' do
+        time = Time.parse('2018-01-06 4:36pm PST')
+        result = save(time.iso8601)
+        expect(result.zone).to eq('-08:00')
+      end
+
+      it 'allows nils' do
+        expect(save(nil)).to eq(nil)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when hash' do
+      before do
+        klass.attribute :age, :hash
+      end
+
+      it 'works' do
+        expect(save({ foo: 'bar' })).to eq(foo: 'bar')
+      end
+
+      # I'm OK with eventually coercing to symbols, but this seems fine
+      it 'allows string keys' do
+        expect(save({ 'foo' => 'bar' })).to eq('foo' => 'bar')
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save([:foo, :bar])
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when array' do
+      before do
+        klass.attribute :age, :array
+      end
+
+      it 'works' do
+        expect(save([:foo, :bar])).to eq([:foo, :bar])
+      end
+
+      it 'raises error on single values' do
+        expect {
+          save(:foo)
+        }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+      end
+
+      it 'does NOT allow nils' do
+        expect {
+          save(nil)
+        }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save({})
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    # test for all array_of_*
+    context 'when array_of_integers' do
+      before do
+        klass.attribute :age, :array_of_integers
+      end
+
+      it 'works' do
+        expect(save([1, 2])).to eq([1, 2])
+      end
+
+      it 'applies basic coercion' do
+        expect(save(['1', '2'])).to eq([1, 2])
+      end
+
+      it 'raises error on single values' do
+        expect {
+          save(1)
+        }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+      end
+
+      it 'raises error on nils' do
+        expect {
+          save(nil)
+        }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+      end
+
+      context 'when cannot coerce' do
+        it 'raises error' do
+          expect {
+            save(nil)
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
+        end
+      end
+    end
+
+    context 'when custom type' do
+      before do
+        type = Dry::Types::Definition
+          .new(nil)
+          .constructor { |input|
+            'custom!'
+          }
+        JsonapiCompliable::Types[:custom] = { write: type }
+        klass.attribute :age, :custom
+      end
+
+      after do
+        JsonapiCompliable::Types.map.delete(:custom)
+      end
+
+      it 'works' do
+        expect(save('foo')).to eq('custom!')
+      end
+    end
+  end
+
+  describe 'nested writes' do
+    describe 'has_many' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Jane' },
+            relationships: {
+              positions: {
+                data: [{
+                  type: 'positions',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }]
+              }
+            }
+          },
+          included: [
+            {
+              type: 'positions',
+              :'temp-id' => 'abc123',
+              attributes: { title: 'mytitle' }
+            }
+          ]
+        }
+      end
+
+      let(:position_model) do
+        Class.new(PORO::Position) do
+          validates :title, presence: true
+
+          def self.name
+            'PORO::Position'
+          end
+        end
+      end
+
+      let(:position_resource) do
+        model = position_model
+        Class.new(PORO::PositionResource) do
+          self.model = model
+          attribute :employee_id, :integer, only: [:writable]
+          attribute :title, :string
+
+          def self.name
+            'PORO::PositionResource'
+          end
+        end
+      end
+
+      before do
+        klass.has_many :positions, resource: position_resource
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.first_name).to eq('Jane')
+        expect(data.positions.length).to eq(1)
+        positions = data.positions
+        expect(positions[0].id).to be_present
+        expect(positions[0].title).to eq('mytitle')
+      end
+
+      context 'when a nested validation error' do
+        before do
+          payload[:included][0].delete(:attributes)
+        end
+
+        it 'responds correctly' do
+          employee = klass.build(payload)
+          expect(employee.save).to eq(false)
+          expect(employee.data.positions[0].errors.full_messages)
+            .to eq(["Title can't be blank"])
+        end
+      end
+    end
+
+    describe 'belongs_to' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            relationships: {
+              classification: {
+                data: {
+                  type: 'classifications',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }
+              }
+            }
+          },
+          included: [
+            {
+              :'temp-id' => 'abc123',
+              type: 'classifications',
+              attributes: { description: 'classy' }
+            }
+          ]
+        }
+      end
+
+      let(:classification_model) do
+        Class.new(PORO::Classification) do
+          validates :description, presence: true
+
+          def self.name
+            'PORO::Classification'
+          end
+        end
+      end
+
+      let(:classification_resource) do
+        model = classification_model
+        Class.new(PORO::ClassificationResource) do
+          self.model = model
+          attribute :description, :string
+
+          def self.name
+            'PORO::ClassificationResource'
+          end
+        end
+      end
+
+      before do
+        klass.attribute :classification_id, :integer, only: [:writable]
+        klass.belongs_to :classification, resource: classification_resource
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.classification).to be_a(classification_model)
+        expect(data.classification.id).to be_present
+        expect(data.classification.description).to eq('classy')
+      end
+
+      context 'when a nested validation error' do
+        before do
+          payload[:included][0].delete(:attributes)
+        end
+
+        it 'responds correctly' do
+          employee = klass.build(payload)
+          expect(employee.save).to eq(false)
+          expect(employee.data.classification.errors.full_messages)
+            .to eq(["Description can't be blank"])
+        end
+      end
+    end
+
+    describe 'has_one' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Jane' },
+            relationships: {
+              bio: {
+                data: {
+                  type: 'bios',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }
+              }
+            }
+          },
+          included: [
+            {
+              type: 'bios',
+              :'temp-id' => 'abc123',
+              attributes: { text: 'mytext' }
+            }
+          ]
+        }
+      end
+
+      let(:bio_model) do
+        Class.new(PORO::Bio) do
+          validates :text, presence: true
+
+          def self.name
+            'PORO::Bio'
+          end
+        end
+      end
+
+      let(:bio_resource) do
+        model = bio_model
+        Class.new(PORO::BioResource) do
+          self.model = model
+          attribute :employee_id, :integer, only: [:writable]
+          attribute :text, :string
+
+          def self.name
+            'PORO::BioResource'
+          end
+        end
+      end
+
+      before do
+        klass.has_one :bio, resource: bio_resource
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.first_name).to eq('Jane')
+        expect(data.bio.id).to be_present
+        expect(data.bio.text).to eq('mytext')
+      end
+
+      context 'when a nested validation error' do
+        before do
+          payload[:included][0].delete(:attributes)
+        end
+
+        it 'responds correctly' do
+          employee = klass.build(payload)
+          expect(employee.save).to eq(false)
+          expect(employee.data.bio.errors.full_messages)
+            .to eq(["Text can't be blank"])
+        end
+      end
+    end
+
+    describe 'many_to_many' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Jane' },
+            relationships: {
+              teams: {
+                data: [{
+                  type: 'teams',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }]
+              }
+            }
+          },
+          included: [
+            {
+              type: 'teams',
+              :'temp-id' => 'abc123',
+              attributes: { name: 'ip' }
+            }
+          ]
+        }
+      end
+
+      let(:team_model) do
+        Class.new(PORO::Team) do
+          validates :name, presence: true
+
+          def self.name
+            'PORO::Team'
+          end
+        end
+      end
+
+      let(:team_resource) do
+        model = team_model
+        Class.new(PORO::TeamResource) do
+          self.model = model
+          attribute :name, :string
+
+          def self.name
+            'PORO::TeamResource'
+          end
+        end
+      end
+
+      before do
+        klass.many_to_many :teams,
+          resource: team_resource,
+          foreign_key: { team_memberships: :team_id }
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.first_name).to eq('Jane')
+        expect(data.teams.length).to eq(1)
+        expect(data.teams[0].name).to eq('ip')
+      end
+
+      context 'when a nested validation error' do
+        before do
+          payload[:included][0].delete(:attributes)
+        end
+
+        it 'responds correctly' do
+          employee = klass.build(payload)
+          expect(employee.save).to eq(false)
+          expect(employee.data.teams[0].errors.full_messages)
+            .to eq(["Name can't be blank"])
+        end
+      end
+    end
+
+    describe 'polymorphic_belongs_to' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            relationships: {
+              credit_card: {
+                data: {
+                  type: 'visas',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }
+              }
+            }
+          },
+          included: [
+            {
+              :'temp-id' => 'abc123',
+              type: 'visas',
+              attributes: { number: 123456 }
+            }
+          ]
+        }
+      end
+
+      let(:visa_model) do
+        Class.new(PORO::Visa) do
+          validates :number, presence: true
+
+          def self.name
+            'PORO::Visa'
+          end
+        end
+      end
+
+      let(:visa_resource) do
+        model = visa_model
+        Class.new(PORO::VisaResource) do
+          self.type = :visas
+          self.model = model
+          attribute :number, :integer
+
+          def self.name
+            'PORO::VisaResource'
+          end
+        end
+      end
+
+      before do
+        resource = visa_resource
+        klass.polymorphic_belongs_to :credit_card do
+          group_by(:credit_card_type) do
+            on(:Visa).belongs_to :visa, resource: resource
+          end
+        end
+      end
+
+      it 'works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.credit_card).to be_a(PORO::Visa)
+        expect(data.credit_card.id).to be_present
+        expect(data.credit_card.number).to eq(123456)
+        expect(data.credit_card_type).to eq(:Visa)
+      end
+    end
+
+    context 'when multiple levels' do
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Jane' },
+            relationships: {
+              positions: {
+                data: [{
+                  type: 'positions',
+                  :'temp-id' => 'abc123',
+                  method: 'create'
+                }]
+              }
+            }
+          },
+          included: [
+            {
+              type: 'positions',
+              :'temp-id' => 'abc123',
+              attributes: { title: 'mytitle' },
+              relationships: {
+                department: {
+                  data: {
+                    type: 'departments',
+                    :'temp-id' => 'abc456',
+                    method: 'create'
+                  }
+                }
+              }
+            },
+            {
+              type: 'departments',
+              :'temp-id' => 'abc456',
+              attributes: { name: 'mydept' }
+            }
+          ]
+        }
+      end
+
+      let(:position_resource) do
+        Class.new(PORO::PositionResource) do
+          self.model = PORO::Position
+          attribute :employee_id, :integer, only: [:writable]
+          attribute :department_id, :integer, only: [:writable]
+          attribute :title, :string
+
+
+          def self.name
+            'PORO::PositionResource'
+          end
+        end
+      end
+
+      let(:department_resource) do
+        Class.new(PORO::DepartmentResource) do
+          self.model = PORO::Department
+
+          attribute :name, :string
+        end
+      end
+
+      before do
+        position_resource.belongs_to :department, resource: department_resource
+        klass.has_many :positions, resource: position_resource
+      end
+
+      it 'still works' do
+        employee = klass.build(payload)
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.positions.length).to eq(1)
+        expect(data.positions[0]).to be_a(PORO::Position)
+        expect(data.positions[0].id).to be_present
+        expect(data.positions[0].title).to eq('mytitle')
+        expect(data.positions[0].department).to be_a(PORO::Department)
+        expect(data.positions[0].department.id).to be_present
+        expect(data.positions[0].department.name).to eq('mydept')
+      end
+    end
+  end
+end

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -52,10 +52,6 @@ class ApplicationController < ActionController::Base
   include Rails.application.routes.url_helpers
   include JsonapiCompliable::Rails
 
-  jsonapi do
-    self.adapter = JsonapiCompliable::Adapters::ActiveRecord::Base.new
-  end
-
   prepend_before_action :fix_params!
 
   private

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -81,12 +81,10 @@ RSpec.describe 'serialization' do
             PORO::Employee.create(age: 'foo')
           end
 
-          # Note ArgumentError not ConstraintError
-          # Unfortunate but not really our purview
           it 'raises error' do
             expect {
               render
-            }.to raise_error(ArgumentError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -116,7 +114,6 @@ RSpec.describe 'serialization' do
           expect(attributes['age']).to eq(nil)
         end
 
-        # Unfortunate we don't get a better error class
         context 'when cannot coerce' do
           before do
             PORO::Employee.create(age: {})
@@ -125,7 +122,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(NoMethodError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -161,7 +158,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(TypeError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -197,7 +194,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -253,7 +250,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -337,7 +334,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -361,7 +358,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -390,7 +387,7 @@ RSpec.describe 'serialization' do
           PORO::Employee.create(age: 1)
           expect {
             render
-          }.to raise_error(Dry::Types::ConstraintError)
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
         end
 
         context 'when cannot coerce' do
@@ -401,7 +398,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end
@@ -430,7 +427,7 @@ RSpec.describe 'serialization' do
           PORO::Employee.create(age: 1)
           expect {
             render
-          }.to raise_error(Dry::Types::ConstraintError)
+          }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
         end
 
         context 'when cannot coerce' do
@@ -441,7 +438,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               render
-            }.to raise_error(Dry::Types::ConstraintError)
+            }.to raise_error(JsonapiCompliable::Errors::TypecastFailed)
           end
         end
       end

--- a/spec/sideload/polymorphic_belongs_to_spec.rb
+++ b/spec/sideload/polymorphic_belongs_to_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe JsonapiCompliable::Sideload::PolymorphicBelongsTo do
       expect(instance.infer_foreign_key).to eq(:foo_id)
     end
   end
+
+  describe '#child_for_type' do
+    let(:child1) { double(resource: double(type: 'foos')) }
+    let(:child2) { double(resource: double(type: 'bars')) }
+
+    before do
+      instance.children = { foo: child1, bar: child2 }
+    end
+
+    it 'returns the child sideload that has a resource with the given type' do
+      expect(instance.child_for_type('bars')).to eq(child2)
+    end
+  end
 end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -193,6 +193,32 @@ RSpec.describe JsonapiCompliable::Sideload do
     end
   end
 
+  describe '#disassociate' do
+    before do
+      opts[:type] = :has_many
+    end
+
+    it 'delegates to parent resource' do
+      parent, child = 'a', 'b'
+      expect(instance.parent_resource).to receive(:disassociate)
+        .with(parent, child, :foo, :has_many)
+      instance.disassociate(parent, child)
+    end
+
+    context 'when given the :as option' do
+      before do
+        opts[:as] = :bar
+      end
+
+      it 'is passed as the association name' do
+        parent, child = 'a', 'b'
+        expect(instance.parent_resource).to receive(:disassociate)
+          .with(parent, child, :bar, :has_many)
+        instance.disassociate(parent, child)
+      end
+    end
+  end
+
   describe '#assign' do
     context 'when a to-many relationship' do
       let(:instance) { JsonapiCompliable::Sideload::HasMany.new(:positions, opts) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 require 'pry'
 
+require 'active_model'
 require 'jsonapi_compliable'
 require 'fixtures/poro'
 

--- a/spec/support/json_helpers.rb
+++ b/spec/support/json_helpers.rb
@@ -4,7 +4,7 @@ module JsonHelpers
   end
 
   def json_item
-    attrs = json['data']['attributes']
+    attrs = json['data']['attributes'] || {}
     attrs['id'] = json['data']['id']
     attrs['_jsonapi_type'] = json['data']['type']
     attrs

--- a/spec/support/resource_testing.rb
+++ b/spec/support/resource_testing.rb
@@ -16,14 +16,14 @@ RSpec.shared_context 'resource testing' do |parameter|
   def render(runtime_options = {})
     ctx = TestRunner.new(resource, params)
     proxy = defined?(base_scope) ? ctx.proxy(base_scope) : ctx.proxy
-    json = ctx.render_jsonapi(proxy, runtime_options)
-    response.body = json
+    response.body = proxy.to_jsonapi(runtime_options)
     json
   end
 
   def records
     ctx = TestRunner.new(resource, params)
-    ctx.proxy(base_scope).to_a
+    proxy = defined?(base_scope) ? ctx.proxy(base_scope) : ctx.proxy
+    proxy.to_a
   end
 
   def response


### PR DESCRIPTION
**There is still refactoring of internals to do**, particularly around the
proxies/runner, but this adds 1.0 support for writes:

```ruby
def create
  employee = EmployeeResource.build(params)

  if employee.save
    render jsonapi: employee
  else
    render jsonapi_errors: employee
  end
end

def update
  employee = EmployeeResource.find(params)

  if employee.update_attributes
    render jsonapi: employee
  else
    render jsonapi_errors: employee
  end
end

def destroy
  employee = EmployeeResource.find(params)

  if employee.destroy
    render jsonapi: employee
  else
    render jsonapi_errors: employee
  end
end
```

This will honor the attribute types, see `spec/persistence_spec.rb` for
detailed usage.

Questions:

* `save` and `update_attributes` functionally do the same thing, and the
alias is just to match rails convention. Is there anything better we can
do here?

Other notes:

* All tests now pass
* This commit wires-up write functionality, it does not refactor the
existing write functionality. This can come later.
* `sort` and `filter` customizations now optionally accept a type. If
given a type, we will create a sort-only or filter-only attribute
under-the-hood. We will still raise errors if not given a type, or if
the attribute was specifically marked unsortable/unfilterable.
* Adds `jsonapi_errorable` as a dependency, which sets us up to remove
the top-level `jsonapi_suite` gem altogether.
* Moves `render_jsonapi` completely from `Base` - this is now
`proxy.to_jsonapi`. It will still respect `def
default_render_jsonapi_options;end` if defined in the controller.
* Adds `Resource#typecast` convenience method.