### PR TITLE
Add support for XML and JSON

### DIFF
--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/hash/conversions' # to_xml
 require 'active_support/concern'
 require 'active_support/time'
 
@@ -73,6 +74,7 @@ require "jsonapi_compliable/query"
 require "jsonapi_compliable/scope"
 require "jsonapi_compliable/deserializer"
 require "jsonapi_compliable/renderer"
+require "jsonapi_compliable/hash_renderer"
 require "jsonapi_compliable/scoping/base"
 require "jsonapi_compliable/scoping/sort"
 require "jsonapi_compliable/scoping/paginate"

--- a/lib/jsonapi_compliable/adapters/active_record/belongs_to_sideload.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/belongs_to_sideload.rb
@@ -8,8 +8,8 @@ module JsonapiCompliable
           resource_class.model.all
         end
 
-        def scope(parents)
-          base_scope.where(primary_key => parents.map(&foreign_key))
+        def scope(parent_ids)
+          base_scope.where(primary_key => parent_ids)
         end
       end
     end

--- a/lib/jsonapi_compliable/adapters/active_record/has_many_sideload.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/has_many_sideload.rb
@@ -8,10 +8,7 @@ module JsonapiCompliable
           resource_class.model.all
         end
 
-        def scope(parents)
-          parent_ids = parents.map(&primary_key)
-          parent_ids.compact!
-          parent_ids.uniq!
+        def scope(parent_ids)
           base_scope.where(foreign_key => parent_ids)
         end
       end

--- a/lib/jsonapi_compliable/adapters/active_record/has_one_sideload.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/has_one_sideload.rb
@@ -8,8 +8,8 @@ module JsonapiCompliable
           resource_class.model.all
         end
 
-        def scope(parents)
-          base_scope.where(foreign_key => parents.map(&primary_key))
+        def scope(parent_ids)
+          base_scope.where(foreign_key => parent_ids)
         end
       end
     end

--- a/lib/jsonapi_compliable/adapters/active_record/many_to_many_sideload.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/many_to_many_sideload.rb
@@ -11,11 +11,7 @@ module JsonapiCompliable
             .reflections[through.to_s].klass.table_name
         end
 
-        def scope(parents)
-          parent_ids = parents.map { |p| p.send(primary_key) }
-          parent_ids.uniq!
-          parent_ids.compact!
-
+        def scope(parent_ids)
           base_scope
             .includes(through)
             .where(through_table_name => { true_foreign_key => parent_ids })

--- a/lib/jsonapi_compliable/hash_renderer.rb
+++ b/lib/jsonapi_compliable/hash_renderer.rb
@@ -1,0 +1,51 @@
+module JsonapiCompliable
+  module SerializableHash
+    def to_hash(fields: nil, include: {})
+      {}.tap do |hash|
+        _fields = fields[jsonapi_type] if fields
+        attrs = requested_attributes(_fields).each_with_object({}) do |(k, v), h|
+          h[k] = instance_eval(&v)
+        end
+        rels = @_relationships.select { |k,v| !!include[k] }
+        rels.each_with_object({}) do |(k, v), h|
+          serializers = v.send(:resources)
+          attrs[k] = if serializers.is_a?(Array)
+            serializers.map do |rr| # use private method to avoid array casting
+              rr.to_hash(fields: fields, include: include[k])
+            end
+          else
+            serializers.to_hash(fields: fields, include: include[k])
+          end
+        end
+
+        hash[:id] = jsonapi_id
+        hash.merge!(attrs) if attrs.any?
+      end
+    end
+  end
+  JSONAPI::Serializable::Resource.send(:include, SerializableHash)
+
+  class HashRenderer
+    def render(options)
+      serializers = options[:data]
+      opts = options.slice(:fields, :include)
+      to_hash(serializers, opts).tap do |hash|
+        hash.merge!(options.slice(:meta)) if !options[:meta].empty?
+      end
+    end
+
+    private
+
+    def to_hash(serializers, opts)
+      {}.tap do |hash|
+        if serializers.is_a?(Array)
+          hash[serializers[0].jsonapi_type] = serializers.map do |s|
+            s.to_hash(opts)
+          end
+        else
+          hash[serializers.jsonapi_type] = serializers.to_hash(opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/resource_proxy.rb
+++ b/lib/jsonapi_compliable/resource_proxy.rb
@@ -38,6 +38,14 @@ module JsonapiCompliable
       Renderer.new(self, options).to_jsonapi
     end
 
+    def to_json(options = {})
+      Renderer.new(self, options).to_json
+    end
+
+    def to_xml(options = {})
+      Renderer.new(self, options).to_xml
+    end
+
     def to_a
       records = @scope.resolve
       if records.empty? && raise_on_missing?

--- a/lib/jsonapi_compliable/sideload.rb
+++ b/lib/jsonapi_compliable/sideload.rb
@@ -209,6 +209,13 @@ module JsonapiCompliable
       parent_resource.disassociate(parent, child, association_name, type)
     end
 
+    def ids_for_parents(parents)
+      parent_ids = parents.map(&primary_key)
+      parent_ids.compact!
+      parent_ids.uniq!
+      parent_ids
+    end
+
     private
 
     def load_options(parents, query)
@@ -238,10 +245,16 @@ module JsonapiCompliable
     end
 
     def fire_scope(parents)
+      parent_ids = ids_for_parents(parents)
       if self.class.scope_proc
-        instance_exec(parents, &self.class.scope_proc)
+        instance_exec(parent_ids, parents, &self.class.scope_proc)
       else
-        scope(parents)
+        method = method(:scope)
+        if [2,-2].include?(method.arity)
+          scope(parent_ids, parents)
+        else
+          scope(parent_ids)
+        end
       end
     end
 

--- a/lib/jsonapi_compliable/sideload/belongs_to.rb
+++ b/lib/jsonapi_compliable/sideload/belongs_to.rb
@@ -6,7 +6,7 @@ class JsonapiCompliable::Sideload::BelongsTo < JsonapiCompliable::Sideload
   def load_params(parents, query)
     query.to_hash.tap do |hash|
       hash[:filter] ||= {}
-      hash[:filter][primary_key] = parents.map(&foreign_key)
+      hash[:filter][primary_key] = ids_for_parents(parents)
     end
   end
 
@@ -16,6 +16,13 @@ class JsonapiCompliable::Sideload::BelongsTo < JsonapiCompliable::Sideload
 
   def associate(parent, child)
     parent_resource.associate(parent, child, association_name, type)
+  end
+
+  def ids_for_parents(parents)
+    parent_ids = parents.map(&foreign_key)
+    parent_ids.compact!
+    parent_ids.uniq!
+    parent_ids
   end
 
   def infer_foreign_key

--- a/lib/jsonapi_compliable/sideload/has_many.rb
+++ b/lib/jsonapi_compliable/sideload/has_many.rb
@@ -6,7 +6,7 @@ class JsonapiCompliable::Sideload::HasMany < JsonapiCompliable::Sideload
   def load_params(parents, query)
     query.to_hash.tap do |hash|
       hash[:filter] ||= {}
-      hash[:filter][foreign_key] = parents.map(&primary_key)
+      hash[:filter][foreign_key] = ids_for_parents(parents)
     end
   end
 

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -163,16 +163,22 @@ RSpec.describe 'filtering' do
         assert_filter_value(false)
       end
 
-      it 'coerces integers' do
+      it 'coerces true integers' do
         params[:filter] = { foo: 1 }
         assert_filter_value(true)
+      end
+
+      it 'coerces false integers' do
         params[:filter] = { foo: 0 }
         assert_filter_value(false)
       end
 
-      it 'coerces string integers' do
+      it 'coerces string true integers' do
         params[:filter] = { foo: '1' }
         assert_filter_value(true)
+      end
+
+      it 'coerces string false integers' do
         params[:filter] = { foo: '0' }
         assert_filter_value(false)
       end

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -149,6 +149,7 @@ module PORO
 
   class Position < Base
     attr_accessor :title,
+      :rank,
       :employee_id,
       :e_id,
       :employee,
@@ -269,25 +270,39 @@ module PORO
   class ApplicationResource < JsonapiCompliable::Resource
     self.adapter = Adapter.new
     self.abstract_class = true
+
+    def base_scope
+      { type: self.model.name.demodulize.underscore.pluralize.to_sym }
+    end
   end
 
   class EmployeeResource < ApplicationResource
     self.serializer = PORO::EmployeeSerializer
-
     attribute :first_name, :string
     attribute :last_name, :string
-    attribute :age, :string
-
+    attribute :age, :integer
+    extra_attribute :worth, :integer do
+      100
+    end
+    allow_stat total: :count
     has_many :positions
   end
 
   class PositionResource < ApplicationResource
+    attribute :employee_id, :integer, only: [:filterable]
+    attribute :title, :string
+    attribute :rank, :integer
+    extra_attribute :score, :integer do
+      200
+    end
+    belongs_to :department
   end
 
   class ClassificationResource < ApplicationResource
   end
 
   class DepartmentResource < ApplicationResource
+    attribute :name, :string
   end
 
   class BioResource < ApplicationResource

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -1,0 +1,239 @@
+require 'spec_helper'
+
+RSpec.describe 'serialization' do
+  include_context 'resource testing'
+  let(:resource) do
+    Class.new(PORO::EmployeeResource) do
+      def self.name
+        'PORO::EmployeeResource'
+      end
+    end
+  end
+  let(:base_scope) { { type: :employees } }
+
+  let!(:employee1) do
+    PORO::Employee.create first_name: 'John',
+      last_name: 'Doe',
+      age: 33
+  end
+  let!(:employee2) do
+    PORO::Employee.create first_name: 'Jane',
+      last_name: 'Dougherty',
+      age: 44
+  end
+  let!(:position1) do
+    PORO::Position.create title: 'title1',
+      rank: 1,
+      employee_id: 1,
+      department_id: 1
+  end
+  let!(:position2) do
+    PORO::Position.create title: 'title2',
+      rank: 2,
+      employee_id: 2,
+      department_id: 2
+  end
+  let!(:department1) do
+    PORO::Department.create(name: 'dep1')
+  end
+  let!(:department2) do
+    PORO::Department.create(name: 'dep2')
+  end
+
+  before do
+    params[:include] = 'positions.department'
+  end
+
+  def json
+    JSON.parse(proxy.to_json)['employees']
+  end
+
+  def xml
+    xml = proxy.to_xml
+    Hash.from_xml(xml)['data']['employees']
+  end
+
+  context 'when rendering vanilla json' do
+    it 'works' do
+      params.delete(:include)
+      expect(json).to be_a(Array)
+      expect(json.length).to eq(2)
+      expect(json[0]).to eq({
+        'id' => '1',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'age' => 33
+      })
+      expect(json[1]).to eq({
+        'id' => '2',
+        'first_name' => 'Jane',
+        'last_name' => 'Dougherty',
+        'age' => 44
+      })
+    end
+
+    it 'accepts runtime options' do
+      json = JSON.parse(proxy.to_json(meta: { foo: 'bar' }))
+      expect(json['meta']).to eq('foo' => 'bar')
+    end
+
+    context 'when sideloading' do
+      it 'works' do
+        expect(json[0]['positions']).to eq([
+          'id' => '1',
+          'title' => 'title1',
+          'rank' => 1,
+          'department' => { 'id' => '1', 'name' => 'dep1' }
+        ])
+        expect(json[1]['positions']).to eq([
+          'id' => '2',
+          'title' => 'title2',
+          'rank' => 2,
+          'department' => { 'id' => '2',  'name' => 'dep2' }
+        ])
+      end
+    end
+
+    context 'when sparse fields' do
+      before do
+        params[:fields] = { employees: 'first_name', positions: 'rank' }
+      end
+
+      it 'works' do
+        expect(json[0].keys).to eq(%w(id first_name positions))
+        expect(json[0]['positions'][0].keys).to eq(%w(id rank department))
+      end
+    end
+
+    context 'when extra fields' do
+      before do
+        params[:extra_fields] = { employees: 'worth', positions: 'score' }
+      end
+
+      it 'works' do
+        expect(json[0]['worth']).to eq(100)
+        expect(json[0]['positions'][0]['score']).to eq(200)
+      end
+    end
+
+    context 'when not rendering meta' do
+      it 'does not render the meta key' do
+        json = JSON.parse(proxy.to_json)
+        expect(json).to_not have_key('meta')
+      end
+    end
+
+    context 'when rendering meta' do
+      before do
+        params[:stats] = { total: 'count' }
+      end
+
+      it 'works' do
+        json = JSON.parse(proxy.to_json)
+        expect(json['meta']).to eq({
+          'stats' => { 'total' => { 'count' => 'poro_count_total' } }
+        })
+      end
+
+      it 'merges runtime meta' do
+        json = JSON.parse(proxy.to_json(meta: { foo: 'bar' }))
+        expect(json['meta']).to eq({
+          'foo' => 'bar',
+          'stats' => { 'total' => { 'count' => 'poro_count_total' } }
+        })
+      end
+    end
+  end
+
+  context 'when rendering xml' do
+    it 'works' do
+      params.delete(:include)
+      expect(xml).to be_a(Array)
+      expect(xml.length).to eq(2)
+      expect(xml[0]).to eq({
+        'id' => '1',
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'age' => 33
+      })
+      expect(xml[1]).to eq({
+        'id' => '2',
+        'first_name' => 'Jane',
+        'last_name' => 'Dougherty',
+        'age' => 44
+      })
+    end
+
+    it 'accepts runtime options' do
+      xml = Hash.from_xml(proxy.to_xml(meta: { foo: 'bar' }))
+      expect(xml['data']['meta']).to eq('foo' => 'bar')
+    end
+
+    context 'when sideloading' do
+      it 'works' do
+        expect(xml[0]['positions']).to eq([
+          'id' => '1',
+          'title' => 'title1',
+          'rank' => 1,
+          'department' => { 'id' => '1', 'name' => 'dep1' }
+        ])
+        expect(xml[1]['positions']).to eq([
+          'id' => '2',
+          'title' => 'title2',
+          'rank' => 2,
+          'department' => { 'id' => '2',  'name' => 'dep2' }
+        ])
+      end
+    end
+
+    context 'when sparse fields' do
+      before do
+        params[:fields] = { employees: 'first_name', positions: 'rank' }
+      end
+
+      it 'works' do
+        expect(xml[0].keys).to eq(%w(id first_name positions))
+        expect(xml[0]['positions'][0].keys).to eq(%w(id rank department))
+      end
+    end
+
+    context 'when extra fields' do
+      before do
+        params[:extra_fields] = { employees: 'worth', positions: 'score' }
+      end
+
+      it 'works' do
+        expect(xml[0]['worth']).to eq(100)
+        expect(xml[0]['positions'][0]['score']).to eq(200)
+      end
+    end
+
+    context 'when not rendering meta' do
+      it 'does not render the meta key' do
+        xml = Hash.from_xml(proxy.to_xml)
+        expect(xml['data']).to_not have_key('meta')
+      end
+    end
+
+    context 'when rendering meta' do
+      before do
+        params[:stats] = { total: 'count' }
+      end
+
+      it 'works' do
+        xml = Hash.from_xml(proxy.to_xml)['data']
+        expect(xml['meta']).to eq({
+          'stats' => { 'total' => { 'count' => 'poro_count_total' } }
+        })
+      end
+
+      it 'merges runtime meta' do
+        xml = Hash.from_xml(proxy.to_xml(meta: { foo: 'bar' }))['data']
+        expect(xml['meta']).to eq({
+          'foo' => 'bar',
+          'stats' => { 'total' => { 'count' => 'poro_count_total' } }
+        })
+      end
+    end
+  end
+end

--- a/spec/sideload/belongs_to_spec.rb
+++ b/spec/sideload/belongs_to_spec.rb
@@ -75,6 +75,40 @@ RSpec.describe JsonapiCompliable::Sideload::BelongsTo do
     end
   end
 
+  describe '#ids_for_parents' do
+    let(:parent1) { double(employee_id: 11) }
+    let(:parent2) { double(employee_id: 22) }
+    let(:parents) { [parent1, parent2] }
+
+    subject(:ids) { instance.ids_for_parents(parents) }
+
+    it 'maps over the primary key' do
+      expect(ids).to eq([11, 22])
+    end
+
+    it 'does not return duplicates' do
+      parents << double(employee_id: 22)
+      expect(ids).to eq([11, 22])
+    end
+
+    it 'does not return nils' do
+      parents << double(employee_id: nil)
+      expect(ids).to eq([11, 22])
+    end
+
+    context 'with custom foreign key' do
+      let(:parents) { [double(foo: 44), double(foo: 55)] }
+
+      before do
+        opts[:foreign_key] = :foo
+      end
+
+      it 'still works' do
+        expect(ids).to eq([44, 55])
+      end
+    end
+  end
+
   describe 'infer_foreign_key' do
     let(:opts) { { resource: resource } }
     let(:resource) do

--- a/spec/support/resource_testing.rb
+++ b/spec/support/resource_testing.rb
@@ -14,16 +14,20 @@ RSpec.shared_context 'resource testing' do |parameter|
   #   render
   # end
   def render(runtime_options = {})
-    ctx = TestRunner.new(resource, params)
-    proxy = defined?(base_scope) ? ctx.proxy(base_scope) : ctx.proxy
-    response.body = proxy.to_jsonapi(runtime_options)
+    json = proxy.to_jsonapi(runtime_options)
+    response.body = json
     json
   end
 
+  def proxy
+    @proxy ||= begin
+      ctx = TestRunner.new(resource, params)
+      defined?(base_scope) ? ctx.proxy(base_scope) : ctx.proxy
+    end
+  end
+
   def records
-    ctx = TestRunner.new(resource, params)
-    proxy = defined?(base_scope) ? ctx.proxy(base_scope) : ctx.proxy
-    proxy.to_a
+    proxy.data
   end
 
   def response


### PR DESCRIPTION
The beginning of support for multiple content types. You can now do
this:

```ruby
employees = EmployeeResource.all(params)
employees.to_json # simple plain json
employees.to_xml # plain json in xml format
employees.to_jsonapi # json in jsonapi format
```

All serialization, sparse fields and "sideloads" will be respected. When
rendering JSON, the top-level keys are `employees` (or whatever the
jsonapi "type" is) and `meta`. This way we can continue to support total
count and other metadata.

With some minor additions to a Rails app + responders gem, which we will
add to our generator, that means this:

```ruby
def index
  employees = EmployeeResource.all(params)
  respond_with(employees)
end
```

Will render the approprate response based on the request format
(`.json`, `.xml`, `.jsonapi`), or content type (`application/json`,
`application/xml`, `application/vnd.api+json'`).

Note there are no custom `xml` or `json` renderers registered in the
Railtie! Our proxy object correctly responds to `to_xml` and `to_json`,
so it works out-of-the-box, even alongside existing APIs already
rendering vanilla json.

Some exceptions:

* Write payloads are still jsonapi-only. Would not be particularly hard
to support other formats, but not worth even the minor effort at this
point.
* This means we could accept different query payloads as well (again,
just not worth it right now).
* Errors are still always in jsonapi format. Again, I'd like to have a
real-life use case before supporting others.

Other notes:

* Ensure sideloads resolve with unique, non-nil parent ids by the new
`#ids_for_parents` method, which will be passed to `.scope` or used
within `#load_params`.