### PR TITLE
Add advanced filtering

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,14 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "appraisal"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  if ENV["APPRAISAL_INITIALIZED"]
+    t.pattern = 'spec/integration/rails'
+  end
+end
 
 if !ENV["APPRAISAL_INITIALIZED"] && !ENV["TRAVIS"]
-  task :default => :appraisal
+  task :default => [:spec, :appraisal]
 else
-  task :default => :spec
+  task :default => [:spec]
 end

--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'forwardable'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/hash/conversions' # to_xml
@@ -75,6 +76,7 @@ require "jsonapi_compliable/scope"
 require "jsonapi_compliable/deserializer"
 require "jsonapi_compliable/renderer"
 require "jsonapi_compliable/hash_renderer"
+require "jsonapi_compliable/filter_operators"
 require "jsonapi_compliable/scoping/base"
 require "jsonapi_compliable/scoping/sort"
 require "jsonapi_compliable/scoping/paginate"

--- a/lib/jsonapi_compliable/adapters/abstract.rb
+++ b/lib/jsonapi_compliable/adapters/abstract.rb
@@ -76,17 +76,180 @@ module JsonapiCompliable
     # @see Adapters::ActiveRecordSideloading
     # @see Adapters::Null
     class Abstract
-      # @param scope The scope object we are chaining
-      # @param [Symbol] attribute The attribute name we are filtering
-      # @param value The corresponding query parameter value
-      # @return the scope
-      #
-      # @example ActiveRecord default
-      #   def filter(scope, attribute, value)
-      #     scope.where(attribute => value)
-      #   end
-      def filter(scope, attribute, value)
-        raise 'you must override #filter in an adapter subclass'
+      def filter_string_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_eq)
+      end
+
+      def filter_string_eql(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_eql)
+      end
+
+      def filter_string_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_not_eq)
+      end
+
+      def filter_string_not_eql(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_not_eql)
+      end
+
+      def filter_string_prefix(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_prefix)
+      end
+
+      def filter_string_not_prefix(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_not_prefix)
+      end
+
+      def filter_string_suffix(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_suffix)
+      end
+
+      def filter_string_not_suffix(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_not_suffix)
+      end
+
+      def filter_string_like(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_like)
+      end
+
+      def filter_string_not_like(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_not_like)
+      end
+
+      def filter_integer_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_eq)
+      end
+
+      def filter_integer_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_not_eq)
+      end
+
+      def filter_integer_gt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_gt)
+      end
+
+      def filter_integer_gte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_gte)
+      end
+
+      def filter_integer_lt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_lt)
+      end
+
+      def filter_integer_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_integer_lte)
+      end
+
+      def filter_datetime_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_eq)
+      end
+
+      def filter_datetime_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_not_eq)
+      end
+
+      def filter_datetime_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_lte)
+      end
+
+      def filter_float_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_eq)
+      end
+
+      def filter_float_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_not_eq)
+      end
+
+      def filter_float_gt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_gt)
+      end
+
+      def filter_float_gte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_gte)
+      end
+
+      def filter_float_lt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_lt)
+      end
+
+      def filter_float_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_float_lte)
+      end
+
+      def filter_decimal_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_eq)
+      end
+
+      def filter_decimal_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_not_eq)
+      end
+
+      def filter_decimal_gt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_gt)
+      end
+
+      def filter_decimal_gte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_gte)
+      end
+
+      def filter_decimal_lt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_lt)
+      end
+
+      def filter_decimal_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_decimal_lte)
+      end
+
+      def filter_datetime_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_eq)
+      end
+
+      def filter_datetime_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_not_eq)
+      end
+
+      def filter_datetime_gt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_gt)
+      end
+
+      def filter_datetime_gte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_gte)
+      end
+
+      def filter_datetime_lt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_lt)
+      end
+
+      def filter_datetime_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_datetime_lte)
+      end
+
+      def filter_date_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_eq)
+      end
+
+      def filter_date_not_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_not_eq)
+      end
+
+      def filter_date_gt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_gt)
+      end
+
+      def filter_date_gte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_gte)
+      end
+
+      def filter_date_lt(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_lt)
+      end
+
+      def filter_date_lte(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_date_lte)
+      end
+
+      def filter_boolean_eq(scope, attribute, value)
+        raise Errors::AdapterNotImplemented.new(self, attribute, :filter_boolean_eq)
       end
 
       def base_scope(model)
@@ -213,6 +376,12 @@ module JsonapiCompliable
       # @return an array of Model instances
       def resolve(scope)
         scope
+      end
+
+      def associate_all(parent, children, association_name, association_type)
+        children.each do |c|
+          associate(parent, c, association_name, association_type)
+        end
       end
 
       # Probably want to override

--- a/lib/jsonapi_compliable/adapters/null.rb
+++ b/lib/jsonapi_compliable/adapters/null.rb
@@ -4,8 +4,179 @@ module JsonapiCompliable
     # Useful when your customization does not support all possible
     # configuration (e.g. the service you hit does not support sorting)
     class Null < Abstract
-      # (see Adapters::Abstract#filter)
-      def filter(scope, attribute, value)
+      def filter_string_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_eql(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_not_eql(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_prefix_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_not_prefix_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_suffix_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_not_suffix_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_like_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_string_not_like_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_gt(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_gte(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_lt(scope, attribute, value)
+        scope
+      end
+
+      def filter_integer_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_gt(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_gte(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_lt(scope, attribute, value)
+        scope
+      end
+
+      def filter_float_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_gt(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_gte(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_lt(scope, attribute, value)
+        scope
+      end
+
+      def filter_decimal_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_gt(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_gte(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_lt(scope, attribute, value)
+        scope
+      end
+
+      def filter_datetime_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_not_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_gt(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_gte(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_lt(scope, attribute, value)
+        scope
+      end
+
+      def filter_date_lte(scope, attribute, value)
+        scope
+      end
+
+      def filter_boolean_eq(scope, attribute, value)
         scope
       end
 

--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -2,6 +2,20 @@ module JsonapiCompliable
   module Errors
     class Base < StandardError;end
 
+    class AdapterNotImplemented < Base
+      def initialize(adapter, attribute, method)
+        @adapter = adapter
+        @attribute = attribute
+        @method = method
+      end
+
+      def message
+        <<-MSG
+The adapter #{@adapter.class} does not implement method '#{@method}', which was requested for attribute '#{@attribute}'. Add this method to your adapter to support this filter operator.
+        MSG
+      end
+    end
+
     class AttributeError < Base
       attr_reader :resource,
         :name,

--- a/lib/jsonapi_compliable/filter_operators.rb
+++ b/lib/jsonapi_compliable/filter_operators.rb
@@ -1,0 +1,25 @@
+module JsonapiCompliable
+  class FilterOperators
+    class Catchall
+      attr_reader :procs
+
+      def initialize
+        @procs = {}
+      end
+
+      def method_missing(name, *args, &blk)
+        @procs[name] = blk
+      end
+
+      def to_hash
+        @procs
+      end
+    end
+
+    def self.build(&blk)
+      c = Catchall.new
+      c.instance_eval(&blk) if blk
+      c.to_hash
+    end
+  end
+end

--- a/lib/jsonapi_compliable/hash_renderer.rb
+++ b/lib/jsonapi_compliable/hash_renderer.rb
@@ -26,6 +26,10 @@ module JsonapiCompliable
   JSONAPI::Serializable::Resource.send(:include, SerializableHash)
 
   class HashRenderer
+    def initialize(resource)
+      @resource = resource
+    end
+
     def render(options)
       serializers = options[:data]
       opts = options.slice(:fields, :include)
@@ -39,11 +43,11 @@ module JsonapiCompliable
     def to_hash(serializers, opts)
       {}.tap do |hash|
         if serializers.is_a?(Array)
-          hash[serializers[0].jsonapi_type] = serializers.map do |s|
+          hash[@resource.type] = serializers.map do |s|
             s.to_hash(opts)
           end
         else
-          hash[serializers.jsonapi_type] = serializers.to_hash(opts)
+          hash[@resource.type] = serializers.to_hash(opts)
         end
       end
     end

--- a/lib/jsonapi_compliable/railtie.rb
+++ b/lib/jsonapi_compliable/railtie.rb
@@ -13,7 +13,25 @@ module JsonapiCompliable
       if Mime[:jsonapi].nil? # rails 4
         Mime::Type.register('application/vnd.api+json', :jsonapi)
       end
+      register_parameter_parser
       register_renderers
+    end
+
+    # from jsonapi-rails
+    PARSER = lambda do |body|
+      data = JSON.parse(body)
+      hash = { _jsonapi: data }
+
+      hash[:format] = :jsonapi
+      hash.with_indifferent_access
+    end
+
+    def register_parameter_parser
+      if ::Rails::VERSION::MAJOR >= 5
+        ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
+      else
+        ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] = PARSER
+      end
     end
 
     def register_renderers

--- a/lib/jsonapi_compliable/renderer.rb
+++ b/lib/jsonapi_compliable/renderer.rb
@@ -18,11 +18,11 @@ module JsonapiCompliable
     end
 
     def to_json
-      render(JsonapiCompliable::HashRenderer.new).to_json
+      render(JsonapiCompliable::HashRenderer.new(@proxy.resource)).to_json
     end
 
     def to_xml
-      render(JsonapiCompliable::HashRenderer.new).to_xml(root: :data)
+      render(JsonapiCompliable::HashRenderer.new(@proxy.resource)).to_xml(root: :data)
     end
 
     private

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -62,6 +62,10 @@ module JsonapiCompliable
       adapter.destroy(model, id)
     end
 
+    def associate_all(parent, children, association_name, type)
+      adapter.associate_all(parent, children, association_name, type)
+    end
+
     def associate(parent, child, association_name, type)
       adapter.associate(parent, child, association_name, type)
     end

--- a/lib/jsonapi_compliable/resource/configuration.rb
+++ b/lib/jsonapi_compliable/resource/configuration.rb
@@ -84,8 +84,9 @@ module JsonapiCompliable
           default(klass, :relationships_writable_by_default, true)
 
           unless klass.config[:attributes][:id]
-            klass.attribute :id, :string
+            klass.attribute :id, :integer_id
           end
+          klass.stat total: [:count]
         end
       end
 

--- a/lib/jsonapi_compliable/resource/polymorphism.rb
+++ b/lib/jsonapi_compliable/resource/polymorphism.rb
@@ -16,6 +16,12 @@ module JsonapiCompliable
         end
       end
 
+      def associate_all(parent, children, association_name, type)
+        children.each do |c|
+          associate(parent, c, association_name, type)
+        end
+      end
+
       def associate(parent, child, association_name, type)
         child_resource = self.class.resource_for_model(parent)
         if child_resource.sideloads[association_name]

--- a/lib/jsonapi_compliable/scope.rb
+++ b/lib/jsonapi_compliable/scope.rb
@@ -1,6 +1,6 @@
 module JsonapiCompliable
   class Scope
-    attr_reader :object, :unpaginated_object
+    attr_accessor :object, :unpaginated_object
 
     def initialize(object, resource, query, opts = {})
       @object    = object

--- a/lib/jsonapi_compliable/sideload/belongs_to.rb
+++ b/lib/jsonapi_compliable/sideload/belongs_to.rb
@@ -14,10 +14,6 @@ class JsonapiCompliable::Sideload::BelongsTo < JsonapiCompliable::Sideload
     children.find { |c| c.send(primary_key) == parent.send(foreign_key) }
   end
 
-  def associate(parent, child)
-    parent_resource.associate(parent, child, association_name, type)
-  end
-
   def ids_for_parents(parents)
     parent_ids = parents.map(&foreign_key)
     parent_ids.compact!

--- a/lib/jsonapi_compliable/util/persistence.rb
+++ b/lib/jsonapi_compliable/util/persistence.rb
@@ -108,7 +108,11 @@ class JsonapiCompliable::Util::Persistence
           if x[:sideload].type == :belongs_to
             x[:sideload].associate(object, x[:object])
           else
-            x[:sideload].associate(x[:object], object)
+            if [:has_many, :many_to_many].include?(x[:sideload].type)
+              x[:sideload].associate_all(object, Array(x[:object]))
+            else
+              x[:sideload].associate(x[:object], object)
+            end
           end
         end
       end
@@ -125,7 +129,11 @@ class JsonapiCompliable::Util::Persistence
             x[:sideload].disassociate(object, x[:object])
           end # otherwise, no need to disassociate destroyed objects
         else
-          x[:sideload].associate(object, x[:object])
+          if [:has_many, :many_to_many].include?(x[:sideload].type)
+            x[:sideload].associate_all(object, Array(x[:object]))
+          else
+            x[:sideload].associate(object, x[:object])
+          end
         end
       end
     end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -3,10 +3,14 @@ ActiveRecord::Schema.define(:version => 1) do
     t.boolean :active, default: true
     t.string :first_name
     t.string :last_name
+    t.integer :age
+    t.float :float_age
+    t.float :decimal_age
     t.string :dwelling_type
     t.integer :state_id
     t.integer :dwelling_id
     t.integer :organization_id
+    t.date :created_at_date
     t.timestamps
   end
 
@@ -249,9 +253,12 @@ module Legacy
 
   class AuthorResource < ApplicationResource
     attribute :first_name, :string
-
-    # todo autostats
-    allow_stat total: [:count]
+    attribute :age, :integer
+    attribute :float_age, :float
+    attribute :decimal_age, :decimal
+    attribute :active, :boolean
+    attribute :created_at, :datetime, only: [:filterable]
+    attribute :created_at_date, :date, only: [:filterable]
 
     has_many :books
     belongs_to :state

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -217,6 +217,15 @@ module PORO
       scope[:conditions].merge!(name => value)
       scope
     end
+    alias :filter_integer_eq :filter
+    alias :filter_string_eq :filter
+    alias :filter_decimal_eq :filter
+    alias :filter_float_eq :filter
+    alias :filter_date_eq :filter
+    alias :filter_datetime_eq :filter
+    alias :filter_boolean_eq :filter
+    alias :filter_hash_eq :filter
+    alias :filter_array_eq :filter
 
     # No need for actual logic to fire
     def count(scope, attr)
@@ -284,7 +293,6 @@ module PORO
     extra_attribute :worth, :integer do
       100
     end
-    allow_stat total: :count
     has_many :positions
   end
 

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -639,7 +639,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
-    describe 'has_and_belongs_to_many nested relationship' do
+    describe 'many_to_many nested relationship' do
       let(:employee) { Employee.create!(first_name: 'Joe') }
       let(:prior_team) { Team.new(name: 'prior') }
       let(:disassociate_team) { Team.new(name: 'disassociate') }

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe JsonapiCompliable::Query do
     department_resource.attribute :description, :string
   end
 
-  xit 'by dot syntax' do
-
-  end
-
   describe '#to_hash' do
     subject(:hash) { instance.to_hash }
 
@@ -225,6 +221,63 @@ RSpec.describe JsonapiCompliable::Query do
 
         it 'parses correctly' do
           expect(hash).to eq(expected)
+        end
+
+        context 'with stringified keys' do
+          before do
+            params.deep_stringify_keys!
+          end
+
+          it 'parses correctly' do
+            expect(hash).to eq(expected)
+          end
+        end
+      end
+
+      context 'via relationship name dot syntax' do
+        before do
+          params[:filter] = { :'positions.title' => { eq: 'asdf' } }
+        end
+
+        let(:expected) do
+          {
+            include: {
+              positions: {
+                filter: { title: { eq: 'asdf' } },
+                include: {
+                  department: { }
+                }
+              }
+            }
+          }
+        end
+
+        it 'parses correctly' do
+          expect(hash).to eq(expected)
+        end
+
+        context 'when multiple levels' do
+          before do
+            params[:filter] = { :'positions.department.name' => { eq: 'asdf' } }
+          end
+
+          let(:expected) do
+            {
+              include: {
+                positions: {
+                  include: {
+                    department: {
+                      filter: { name: { eq: 'asdf' } }
+                    }
+                  }
+                }
+              }
+            }
+          end
+
+          it 'parses correctly' do
+            expect(hash).to eq(expected)
+          end
         end
 
         context 'with stringified keys' do

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe 'serialization' do
       expect(json['meta']).to eq('foo' => 'bar')
     end
 
+    context 'when non-standard resource type' do
+      before do
+        resource.type = :foos
+      end
+
+      it 'uses the resource type as the top-level key' do
+        json = JSON.parse(proxy.to_json)
+        expect(json.keys).to eq(%w(foos))
+      end
+    end
+
     context 'when sideloading' do
       it 'works' do
         expect(json[0]['positions']).to eq([

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe JsonapiCompliable::Resource do
 
     before do
       klass.class_eval do
-        allow_stat :myattr do
+        stat :myattr do
           average { |scope, attr| 1 }
         end
       end
@@ -853,7 +853,7 @@ RSpec.describe JsonapiCompliable::Resource do
         self.adapter = PORO::Adapter.new
         self.model = PORO::Employee
 
-        allow_stat total: [:count]
+        stat total: [:count]
 
         def base_scope
           { type: :employees }
@@ -951,7 +951,7 @@ RSpec.describe JsonapiCompliable::Resource do
       context 'when passed a base scope' do
         before do
           expect(PORO::DB).to receive(:all).with({
-            conditions: { first_name: 'adsf', id: '1'},
+            conditions: { first_name: 'adsf', id: [1] },
             page: 1,
             per: 20
           }).and_call_original

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,12 +22,14 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  if ENV["APPRAISAL_INITIALIZED"]
+    config.pattern = 'spec/integration/rails/**/*'
+  end
 end
 
 # We test rails through appraisal
 if ENV["APPRAISAL_INITIALIZED"]
-  # include folder
-
   require 'database_cleaner'
   require 'kaminari'
   require 'active_record'

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'stats' do
     before do
       params[:stats] = { total: 'count' }
       resource.class_eval do
-        allow_stat total: :count
+        stat total: :count
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe 'stats' do
 
       before do
         resource.class_eval do
-          allow_stat age: [:sum]
+          stat age: [:sum]
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe 'stats' do
 
       before do
         resource.class_eval do
-          allow_stat age: [:average]
+          stat age: [:average]
         end
       end
 
@@ -78,7 +78,7 @@ RSpec.describe 'stats' do
 
       before do
         resource.class_eval do
-          allow_stat age: [:maximum]
+          stat age: [:maximum]
         end
       end
 
@@ -94,7 +94,7 @@ RSpec.describe 'stats' do
 
       before do
         resource.class_eval do
-          allow_stat age: [:minimum]
+          stat age: [:minimum]
         end
       end
 
@@ -110,7 +110,7 @@ RSpec.describe 'stats' do
 
       before do
         resource.class_eval do
-          allow_stat :age do
+          stat :age do
             second { |scope| 1337 }
           end
         end
@@ -131,8 +131,8 @@ RSpec.describe 'stats' do
 
     before do
       resource.class_eval do
-        allow_stat total: :count
-        allow_stat age: [:sum, :average]
+        stat total: :count
+        stat age: [:sum, :average]
       end
     end
 
@@ -145,14 +145,14 @@ RSpec.describe 'stats' do
     end
   end
 
-  context 'when passing symbol to allow_stat' do
+  context 'when passing symbol to stat' do
     before do
       params[:stats] = { age: 'sum' }
     end
 
     before do
       resource.class_eval do
-        allow_stat age: :sum
+        stat age: :sum
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.describe 'stats' do
 
     before do
       resource.class_eval do
-        allow_stat :age do
+        stat :age do
           sum { |scope, attr| "overridden_#{attr}" }
         end
       end
@@ -212,7 +212,7 @@ RSpec.describe 'stats' do
 
     before do
       resource.class_eval do
-        allow_stat total: [:count]
+        stat total: [:count]
       end
     end
 

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -50,4 +50,36 @@ RSpec.describe JsonapiCompliable::Types do
       expect(described_class['string']).to be_present
     end
   end
+
+  describe '.map' do
+    it 'auto-adds canonical name' do
+      expect(described_class.map.values).to all(have_key(:canonical_name))
+    end
+
+    it 'auto-adds array_of_* equivalents' do
+      types = described_class.map.keys
+      expect(types).to include(:array_of_integers)
+      expect(types).to include(:array_of_strings)
+      expect(types).to include(:array_of_datetimes)
+      expect(types).to include(:array_of_dates)
+      expect(types).to include(:array_of_floats)
+      expect(types).to include(:array_of_decimals)
+      expect(types).to include(:array_of_booleans)
+      expect(types).to include(:array_of_hashes)
+      expect(types).to include(:array_of_arrays)
+    end
+  end
+
+  describe '.name_for' do
+    it 'returns canonical name' do
+      expect(described_class.name_for(:array_of_integers)).to eq(:integer)
+    end
+
+    context 'when passed a string' do
+      it 'works' do
+        expect(described_class.name_for('array_of_integers'))
+          .to eq(:integer)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Attributes have types, and types have default filters. For example:

```
 # strings
?filter[name][eq]=foo # case insensitive
?filter[name][eql]=foo # case sensitive
?filter[name][prefix]=fo
?filter[name][suffix]=fo
?filter[name][like]=o
?filter[name]=foo # default is eq

 # add a bang for "not"
?filter[name][!eq]=foo
?filter[name][!like]=o

 # integers, datetimes, etc
?filter[age][eq]=10
?filter[age][gt]=10
?filter[age][gte]=10
?filter[age][lt]=10
?filter[age][lte]=10
```

To customize the logic:

```ruby
 # in your resource
attribute :name, :string

filter :name do
  eq do
    # custom eq logic
  end
end

 # if a corresponding attribute does not exist
filter :foo, :string do
  eq do
    # logic
  end
end

 # you can also add arbitrary operators
filter :foo, :string do
  bar do
    # logic
  end
end
```

Add global operators for types by adding the corresponding method name
to your adapter:

```ruby
def filter_integer_foo(scope, attribute, value)
  # logic
end

 # gives you this, assuming foo is an integer
?filter[age][foo]=111
```

We also now accept dot-notation for relationship filtering. The
"official" syntax will be type-based (`?filter[people][id]=1`) or
relationship dot-based (`?filter[authors.id]=1`). Relationship-based
(`?filter[authors][id]=1`) will be supported but deprecated.

Dot-based filtering can go multiple levels, ie
`?filter[positions.department.name]=foo`.

Other notes:
* Add `associate_all` so ActiveRecord can mark the association as loaded
beforehand (makes sense in any case).
* `rake` now correctly runs plain-ruby tests, then rails-specific tests
with appraisal.
* Adds jsonapi-rails' parameter parser to railtie
* When serializing, cast datetimes as strings for finer-grained control
over the end result.