### PR TITLE
Accomodate the "Sunspot Pattern"

### DIFF
--- a/lib/jsonapi_compliable/adapters/active_record/base.rb
+++ b/lib/jsonapi_compliable/adapters/active_record/base.rb
@@ -199,7 +199,9 @@ module JsonapiCompliable
                 [:create, :update].include?(JsonapiCompliable.context[:namespace])
               parent.send(association_name) << child
             else
-              association.target |= [child]
+              target = association.instance_variable_get(:@target)
+              target |= [child]
+              association.instance_variable_set(:@target, target)
             end
           end
         end
@@ -207,7 +209,7 @@ module JsonapiCompliable
         def associate(parent, child, association_name, association_type)
           association = parent.association(association_name)
           association.loaded!
-          association.target = child
+          association.instance_variable_set(:@target, child)
         end
 
         # When a has_and_belongs_to_many relationship, we don't have a foreign

--- a/lib/jsonapi_compliable/version.rb
+++ b/lib/jsonapi_compliable/version.rb
@@ -1,3 +1,3 @@
 module JsonapiCompliable
-  VERSION = "1.0.alpha.1"
+  VERSION = "1.0.alpha.2"
 end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -94,6 +94,14 @@ module Legacy
     has_many :author_hobbies
     has_many :hobbies, through: :author_hobbies
     has_one :bio
+
+    # This logic should not ever fire
+    has_many :special_books,
+      -> { where(id: 9999) },
+      class_name: 'Legacy::Book'
+    belongs_to :special_state,
+      -> { where(id: 9999) },
+      class_name: 'Legacy::State'
   end
 
   class Organization < ApplicationRecord
@@ -272,5 +280,27 @@ module Legacy
         on(:"Legacy::Condo")
       end
     end
+  end
+
+  class SearchAdapter < JsonapiCompliable::Adapters::Abstract
+    def base_scope(model)
+      model.all
+    end
+
+    def paginate(scope, a, b)
+      scope
+    end
+
+    def resolve(scope)
+      scope.to_a
+    end
+  end
+
+  class AuthorSearchResource < ApplicationResource
+    self.adapter = SearchAdapter.new
+    self.model = Legacy::Author
+
+    has_many :special_books, resource: Legacy::BookResource
+    belongs_to :special_state, resource: Legacy::StateResource
   end
 end

--- a/spec/integration/rails/activerecord_poro_spec.rb
+++ b/spec/integration/rails/activerecord_poro_spec.rb
@@ -1,0 +1,39 @@
+if ENV['APPRAISAL_INITIALIZED']
+  # This tests the 'Sunspot Pattern':
+  # Querying using ElasticSearch, Solr, etc, but returning ActiveRecord objects
+  #
+  # In this scenario, we need to associate the resulting models using the
+  # AR adapter, even though the Resource adapter is not ActiveRecord.
+  # Otherwise, we will try to associate these as if they are POROs - which will
+  # have adverse side-effects because of AR magic.
+  #
+  # This scenario is likely specific to ActiveRecord.
+  RSpec.describe 'a non-ActiveRecord adapter that returns ActiveRecord models', type: :controller do
+    include JsonapiSpecHelpers
+
+    controller(ApplicationController) do
+      def index
+        authors = Legacy::AuthorSearchResource.all(params)
+        render jsonapi: authors
+      end
+    end
+
+    let!(:author) do
+      Legacy::Author.create!(first_name: 'Stephen', state: state)
+    end
+    let!(:book) { Legacy::Book.create!(title: 'Foo', author: author) }
+    let!(:state) { Legacy::State.create!(name: 'Maine') }
+
+    it 'works' do
+      get :index, params: { include: 'special_books' }
+      expect(d[0].sideload(:special_books).map(&:id)).to eq([book.id])
+    end
+
+    context 'belongs_to' do
+      it 'works' do
+        get :index, params: { include: 'special_state' }
+        expect(d[0].sideload(:special_state).id).to eq(state.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
...which is to query using a client, but return ActiveRecord objects.
This would trigger a scenario where the PORO association code would
fire, which has adverse side-effects with ActiveRecord.

Instead, we do a one-off check to ensure adapter developers don't fall
into this trap. The expectation is this scenario is
ActiveRecord-specific, so we're OK with an explicit one-off check.