### PR TITLE
Add schema generation (first-pass)

### DIFF
--- a/lib/jsonapi_compliable.rb
+++ b/lib/jsonapi_compliable.rb
@@ -17,8 +17,10 @@ require "jsonapi_compliable/configuration"
 require "jsonapi_compliable/context"
 require "jsonapi_compliable/errors"
 require "jsonapi_compliable/types"
+require "jsonapi_compliable/schema"
 require "jsonapi_compliable/adapters/abstract"
 require "jsonapi_compliable/resource/sideloading"
+require "jsonapi_compliable/resource/links"
 require "jsonapi_compliable/resource/configuration"
 require "jsonapi_compliable/resource/dsl"
 require "jsonapi_compliable/resource/interface"
@@ -115,6 +117,10 @@ module JsonapiCompliable
   # @see Configuration
   def self.configure
     yield config
+  end
+
+  def self.resources
+    @resources ||= []
   end
 end
 

--- a/lib/jsonapi_compliable/adapters/abstract.rb
+++ b/lib/jsonapi_compliable/adapters/abstract.rb
@@ -76,6 +76,30 @@ module JsonapiCompliable
     # @see Adapters::ActiveRecordSideloading
     # @see Adapters::Null
     class Abstract
+      def default_operators
+        {
+          string: [
+            :eq,
+            :not_eq,
+            :eql,
+            :not_eql,
+            :prefix,
+            :not_prefix,
+            :suffix,
+            :not_suffix,
+            :match,
+            :not_match
+          ],
+          integer_id: numerical_operators,
+          integer: numerical_operators,
+          big_decimal: numerical_operators,
+          float: numerical_operators,
+          boolean: [:eq],
+          date: numerical_operators,
+          datetime: numerical_operators
+        }
+      end
+
       def filter_string_eq(scope, attribute, value)
         raise Errors::AdapterNotImplemented.new(self, attribute, :filter_string_eq)
       end
@@ -499,6 +523,10 @@ module JsonapiCompliable
       end
 
       private
+
+      def numerical_operators
+        [:eq, :not_eq, :gt, :gte, :lt, :lte]
+      end
 
       def activerecord_adapter
         @activerecord_adapter ||=

--- a/lib/jsonapi_compliable/configuration.rb
+++ b/lib/jsonapi_compliable/configuration.rb
@@ -10,6 +10,8 @@ module JsonapiCompliable
 
     attr_accessor :respond_to
 
+    attr_accessor :context_for_endpoint
+
     # Set defaults
     # @api private
     def initialize

--- a/lib/jsonapi_compliable/context.rb
+++ b/lib/jsonapi_compliable/context.rb
@@ -10,6 +10,7 @@ module JsonapiCompliable
 
     included do
       class_attribute :sideload_whitelist
+      self.sideload_whitelist = {}
       class << self;prepend Overrides;end
     end
   end

--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -75,6 +75,34 @@ The adapter #{@adapter.class} does not implement method '#{@method}', which was 
       end
     end
 
+    class InvalidType < Base
+      def initialize(key, value)
+        @key = key
+        @value = value
+      end
+
+      def message
+        "Type must be a Hash with keys #{Types::REQUIRED_KEYS.inspect}"
+      end
+    end
+
+    class ResourceEndpointConflict < Base
+      def initialize(path, action, resource_a, resource_b)
+        @path = path
+        @action = action
+        @resource_a = resource_a
+        @resource_b = resource_b
+      end
+
+      def message
+        <<-MSG
+Both '#{@resource_a}' and '#{@resource_b}' are associated to endpoint #{@path}##{@action}!
+
+Only one resource can be associated to a given url/verb combination.
+        MSG
+      end
+    end
+
     class PolymorphicChildNotFound < Base
       def initialize(resource_class, model)
         @resource_class = resource_class

--- a/lib/jsonapi_compliable/filter_operators.rb
+++ b/lib/jsonapi_compliable/filter_operators.rb
@@ -3,8 +3,18 @@ module JsonapiCompliable
     class Catchall
       attr_reader :procs
 
-      def initialize
+      def initialize(resource, type_name, opts)
         @procs = {}
+        defaults = resource.adapter.default_operators[type_name] || []
+        if opts[:only]
+          defaults = defaults.select { |op| opts[:only].include?(op) }
+        end
+        if opts[:except]
+          defaults = defaults.reject { |op| opts[:except].include?(op) }
+        end
+        defaults.each do |op|
+          @procs[op] = nil
+        end
       end
 
       def method_missing(name, *args, &blk)
@@ -16,8 +26,8 @@ module JsonapiCompliable
       end
     end
 
-    def self.build(&blk)
-      c = Catchall.new
+    def self.build(resource, type_name, opts = {}, &blk)
+      c = Catchall.new(resource, type_name, opts)
       c.instance_eval(&blk) if blk
       c.to_hash
     end

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -4,6 +4,7 @@ module JsonapiCompliable
     include Interface
     include Configuration
     include Sideloading
+    include Links
 
     attr_reader :context
 

--- a/lib/jsonapi_compliable/resource/configuration.rb
+++ b/lib/jsonapi_compliable/resource/configuration.rb
@@ -87,6 +87,7 @@ module JsonapiCompliable
             klass.attribute :id, :integer_id
           end
           klass.stat total: [:count]
+          JsonapiCompliable.resources << klass
         end
       end
 

--- a/lib/jsonapi_compliable/resource/dsl.rb
+++ b/lib/jsonapi_compliable/resource/dsl.rb
@@ -9,11 +9,12 @@ module JsonapiCompliable
 
           if att = get_attr(name, :filterable, raise_error: :only_unsupported)
             aliases = [name, opts[:aliases]].flatten.compact
-            operators = FilterOperators.build(&blk)
+            operators = FilterOperators.build(self, att[:type], opts, &blk)
             config[:filters][name.to_sym] = {
               aliases: aliases,
-              type: att[:type]
-            }.merge(operators.to_hash)
+              type: att[:type],
+              operators: operators.to_hash
+            }
           else
             if type = args[0]
               attribute name, type, only: [:filterable]

--- a/lib/jsonapi_compliable/resource/links.rb
+++ b/lib/jsonapi_compliable/resource/links.rb
@@ -1,0 +1,46 @@
+module JsonapiCompliable
+  module Links
+    extend ActiveSupport::Concern
+
+    module Overrides
+      def endpoint
+        if endpoint = super
+          endpoint
+        else
+          self.endpoint = infer_endpoint
+        end
+      end
+    end
+
+    included do
+      class_attribute :endpoint, :endpoint_namespace, :secondary_endpoints
+      self.secondary_endpoints = []
+
+      class << self
+        prepend Overrides
+      end
+    end
+
+    class_methods do
+      def infer_endpoint
+        path = "/#{name.gsub('Resource', '').pluralize.underscore}"
+        actions = [:index, :show, :create, :update, :destroy]
+        { path: path.to_sym, actions: actions }
+      end
+
+      # NB: avoid << b/c class_attribute
+      def add_endpoint(path, actions)
+        self.secondary_endpoints += [{ path: path.to_sym, actions: actions }]
+      end
+
+      def endpoints
+        ([endpoint] + secondary_endpoints).map do |e|
+          {
+            path: [endpoint_namespace, e[:path]].join('').to_sym,
+            actions: e[:actions]
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/schema.rb
+++ b/lib/jsonapi_compliable/schema.rb
@@ -1,0 +1,150 @@
+module JsonapiCompliable
+  class Schema
+    attr_reader :resources
+
+    def self.generate(resources = nil)
+      ::Rails.application.eager_load! if defined?(::Rails)
+      resources ||= JsonapiCompliable.resources.reject(&:abstract_class?)
+      new(resources).generate
+    end
+
+    def initialize(resources)
+      @resources = resources
+    end
+
+    def generate
+      {
+        resources: generate_resources,
+        endpoints: generate_endpoints,
+        types: generate_types
+      }
+    end
+
+    private
+
+    def generate_types
+      {}.tap do |types|
+        JsonapiCompliable::Types.map.each_pair do |name, config|
+          types[name] = config.slice(:kind, :description)
+        end
+      end
+    end
+
+    def generate_endpoints
+      {}.tap do |endpoints|
+        @resources.each do |r|
+          r.endpoints.each do |e|
+            actions = {}
+            e[:actions].each do |a|
+              next unless ctx = context_for(e[:path], a)
+
+              existing = endpoints[e[:path]]
+              if existing && config = existing[:actions][a]
+                raise Errors::ResourceEndpointConflict.new \
+                  e[:path], a, r.name, config[:resource]
+              end
+
+              actions[a] = { resource: r.name }
+              if whitelist = ctx.sideload_whitelist[a]
+                actions[a].merge!(sideload_whitelist: whitelist)
+              end
+            end
+
+            unless actions.empty?
+              endpoints[e[:path]] ||= { actions: {} }
+              endpoints[e[:path]][:actions].merge!(actions)
+            end
+          end
+        end
+      end
+    end
+
+    def context_for(path, action)
+      JsonapiCompliable.config.context_for_endpoint.call(path, action)
+    end
+
+    def generate_resources
+      @resources.map do |r|
+        config = {
+          name: r.name,
+          type: r.type,
+          attributes: attributes(r),
+          extra_attributes: extra_attributes(r),
+          filters: filters(r),
+          relationships: relationships(r)
+        }
+
+        if r.polymorphic?
+          config.merge!(polymorphic: true, children: r.children.map(&:name))
+        end
+
+        config
+      end
+    end
+
+    def attributes(resource)
+      {}.tap do |attrs|
+        resource.attributes.each_pair do |name, config|
+          if config.values_at(:readable, :writable, :sortable).any?
+            attrs[name] = {
+              type:       config[:type],
+              readable:   flag(config[:readable]),
+              writable:   flag(config[:writable]),
+              sortable:   flag(config[:sortable])
+            }
+          end
+        end
+      end
+    end
+
+    def extra_attributes(resource)
+      {}.tap do |attrs|
+        resource.extra_attributes.each_pair do |name, config|
+          attrs[name] = {
+            type:     config[:type],
+            readable: flag(config[:readable])
+          }
+        end
+      end
+    end
+
+    def flag(value)value
+      if value.is_a?(Symbol)
+        :guarded
+      else
+        !!value
+      end
+    end
+
+    def filters(resource)
+      {}.tap do |f|
+        resource.filters.each_pair do |name, config|
+          config = {
+            type: config[:type],
+            operators: config[:operators].keys
+          }
+          attr = resource.attributes[name]
+          config[:required] = true if attr[:filterable] == :required
+          config[:guard] = true if attr[:filterable].is_a?(Symbol)
+          f[name] = config
+        end
+      end
+    end
+
+    def relationships(resource)
+      {}.tap do |r|
+        resource.sideloads.each_pair do |name, config|
+          schema = { type: config.type }
+          if config.type == :polymorphic_belongs_to
+            schema[:resources] = config.children.values
+              .map(&:resource).map(&:class).map(&:name)
+          else
+            schema[:resource] = config.resource.class.name
+          end
+
+          r[name] = schema
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi_compliable/scoping/filter.rb
+++ b/lib/jsonapi_compliable/scoping/filter.rb
@@ -44,7 +44,7 @@ module JsonapiCompliable
     def filter_scope(filter, operator, value)
       operator = operator.to_s.gsub('!', 'not_').to_sym
 
-      if custom_scope = filter.values.first[operator]
+      if custom_scope = filter.values[0][:operators][operator]
         custom_scope.call(@scope, value, resource.context)
       else
         filter_via_adapter(filter, operator, value)

--- a/lib/jsonapi_compliable/sideload/polymorphic_belongs_to.rb
+++ b/lib/jsonapi_compliable/sideload/polymorphic_belongs_to.rb
@@ -23,12 +23,14 @@ class JsonapiCompliable::Sideload::PolymorphicBelongsTo < JsonapiCompliable::Sid
     def on(name, &blk)
       group = Group.new(name)
       @groups << group
-      group.belongs_to(name.to_s.underscore.to_sym)
       group
     end
 
     def apply(sideload, resource_class)
       @groups.each do |group|
+        if group.calls.empty?
+          group.belongs_to(group.name.to_s.underscore.to_sym)
+        end
         group.calls.each do |call|
           args = call[1]
           opts = args.extract_options!

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -394,7 +394,13 @@ RSpec.describe 'persistence' do
           .constructor { |input|
             'custom!'
           }
-        JsonapiCompliable::Types[:custom] = { write: type }
+        JsonapiCompliable::Types[:custom] = {
+          write: type,
+          read: type,
+          params: type,
+          description: 'test',
+          kind: 'scalar'
+        }
         klass.attribute :age, :custom
       end
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -1,0 +1,531 @@
+require 'spec_helper'
+
+RSpec.describe JsonapiCompliable::Schema do
+  describe '.generate' do
+    subject(:schema) { described_class.generate(resources) }
+
+    let(:expected) do
+      {
+        resources: [
+          {
+            name: 'Schema::EmployeeResource',
+            type: :employees,
+            attributes: {
+              id: {
+                type: :integer_id,
+                readable: true,
+                writable: true,
+                sortable: true
+              },
+              first_name: {
+                type: :string,
+                readable: true,
+                writable: true,
+                sortable: true
+                #description: 'todo'
+              }
+            },
+            filters: {
+              id: {
+                type: :integer_id,
+                operators: JsonapiCompliable::Adapters::Abstract.new.default_operators[:integer]
+              },
+              first_name: {
+                type: :string,
+                operators: JsonapiCompliable::Adapters::Abstract.new.default_operators[:string]
+              },
+              title: {
+                type: :string,
+                operators: JsonapiCompliable::Adapters::Abstract.new.default_operators[:string]
+              }
+            },
+            extra_attributes: {
+              net_sales: {
+                type: :float,
+                readable: true
+              }
+            },
+            relationships: {
+              positions: {
+                resource: 'Schema::PositionResource',
+                type: :has_many
+                #writable: true,
+                #readable: true
+              }
+            }
+          }
+        ],
+        endpoints: {
+          :"/api/v1/schema/employees" => {
+            actions: {
+              index:   { resource: 'Schema::EmployeeResource' },
+              show:    { resource: 'Schema::EmployeeResource' },
+              create:  { resource: 'Schema::EmployeeResource' },
+              update:  { resource: 'Schema::EmployeeResource' },
+              destroy: { resource: 'Schema::EmployeeResource' }
+            }
+          }
+        },
+        types: {
+          integer_id: {
+            kind: 'scalar',
+            description: 'Base Type. Query/persist as integer, render as string.'
+          },
+          string: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          integer: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          big_decimal: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          float: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          boolean: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          date: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          datetime: {
+            kind: 'scalar',
+            description: 'Base Type.'
+          },
+          hash: {
+            kind: 'record',
+            description: 'Base Type.'
+          },
+          array: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_integer_ids: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_strings: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_integers: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_big_decimals: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_floats: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_dates: {
+            kind: 'array',
+            description: 'Base Type.'
+          },
+          array_of_datetimes: {
+            kind: 'array',
+            description: 'Base Type.'
+          }
+        }
+      }
+    end
+
+    let(:application_resource) do
+      Class.new(JsonapiCompliable::Resource) do
+        self.endpoint_namespace = '/api/v1'
+      end
+    end
+
+    let(:employee_resource) do
+      pr = position_resource
+      Class.new(application_resource) do
+        def self.name;'Schema::EmployeeResource';end
+        self.type = :employees
+
+        attribute :first_name, :string
+
+        extra_attribute :net_sales, :float
+
+        filter :title, :string do
+          eq do |scope, value|
+          end
+        end
+
+        has_many :positions, resource: pr
+      end
+    end
+
+    let(:position_resource) do
+      Class.new(PORO::ApplicationResource) do
+        def self.name;'Schema::PositionResource';end
+      end
+    end
+
+    let(:resources) do
+      [employee_resource]
+    end
+
+    let(:test_context) do
+      Class.new do
+        include JsonapiCompliable::Context
+      end
+    end
+
+    around do |e|
+      JsonapiCompliable.config.context_for_endpoint = ->(path, action) {
+        test_context
+      }
+      begin
+        e.run
+      ensure
+        JsonapiCompliable.config.context_for_endpoint = nil
+      end
+    end
+
+    it 'has correct resources' do
+      expect(schema[:resources]).to eq(expected[:resources])
+    end
+
+    it 'has correct endpoints' do
+      expect(schema[:endpoints]).to eq(expected[:endpoints])
+    end
+
+    it 'has correct types' do
+      expect(schema[:types]).to eq(expected[:types])
+    end
+
+    context 'when no resources passed' do
+      subject(:schema) { described_class.generate }
+
+      around do |e|
+        JsonapiCompliable.instance_variable_set(:@resources, [position_resource])
+        begin
+          e.run
+        ensure
+          JsonapiCompliable.instance_variable_set(:@resources, [])
+        end
+      end
+
+      it 'grabs all non-abstract descendants of JsonapiCompliable::Resource' do
+        expect(schema[:resources].length).to eq(1)
+        expect(schema[:resources][0][:name]).to eq('Schema::PositionResource')
+      end
+    end
+
+    context 'when attribute is not readable' do
+      before do
+        employee_resource.class_eval do
+          attribute :first_name, :string, readable: false
+        end
+      end
+
+      it 'is reflected in the schema' do
+        expect(schema[:resources][0][:attributes][:first_name][:readable])
+          .to eq(false)
+      end
+    end
+
+    context 'when attribute is not writable' do
+      before do
+        employee_resource.class_eval do
+          attribute :first_name, :string, writable: false
+        end
+      end
+
+      it 'is reflected in the schema' do
+        expect(schema[:resources][0][:attributes][:first_name][:writable])
+          .to eq(false)
+      end
+    end
+
+    context 'when attribute is not sortable' do
+      before do
+        employee_resource.class_eval do
+          attribute :first_name, :string, sortable: false
+        end
+      end
+
+      it 'is reflected in the schema' do
+        expect(schema[:resources][0][:attributes][:first_name][:sortable])
+          .to eq(false)
+      end
+    end
+
+    context 'when attribute is not filterable' do
+      before do
+        employee_resource.config[:filters] = {}
+        employee_resource.class_eval do
+          attribute :first_name, :string, filterable: false
+        end
+      end
+
+      it 'is not in the list of filters' do
+        expect(schema[:resources][0][:filters]).to_not have_key(:first_name)
+      end
+    end
+
+    context 'when the attribute is guarded' do
+      before do
+        employee_resource.class_eval do
+          attribute :first_name, :string, readable: :admin?
+        end
+      end
+
+      it 'returns :guarded, not the runtime method' do
+        expect(schema[:resources][0][:attributes][:first_name][:readable])
+          .to eq(:guarded)
+      end
+    end
+
+    context 'when the filter is guarded' do
+      before do
+        employee_resource.class_eval do
+          attribute :first_name, :string, filterable: :admin?
+        end
+      end
+
+      it 'flags it as guarded' do
+        expect(schema[:resources][0][:filters][:first_name][:guard])
+          .to eq(true)
+      end
+    end
+
+    context 'when filter is required' do
+      before do
+        employee_resource.config[:filters] = {}
+        employee_resource.class_eval do
+          attribute :first_name, :string, filterable: :required
+        end
+      end
+
+      it 'flags it as required' do
+        expect(schema[:resources][0][:filters][:first_name][:required])
+          .to eq(true)
+      end
+    end
+
+    context 'when attribute supports subset of filter operators via :only' do
+      before do
+        employee_resource.class_eval do
+          filter :first_name, only: [:eq, :prefix]
+        end
+      end
+
+      it 'limits the list of operators for the filter' do
+        expect(schema[:resources][0][:filters][:first_name][:operators])
+          .to eq([:eq, :prefix])
+      end
+    end
+
+    context 'when attribute supports subset of operators via :except' do
+      before do
+        employee_resource.class_eval do
+          filter :first_name, except: [:eq, :not_eq, :eql, :not_eql]
+        end
+      end
+
+      it 'limits the list of operators for the filter' do
+        expect(schema[:resources][0][:filters][:first_name][:operators])
+          .to eq([
+            :prefix,
+            :not_prefix,
+            :suffix,
+            :not_suffix,
+            :match,
+            :not_match
+          ])
+      end
+    end
+
+    context 'when extra attribute is guarded' do
+      before do
+        employee_resource.class_eval do
+          extra_attribute :net_sales, :float, readable: :admin?
+        end
+      end
+
+      it 'returns :guarded, not the runtime method' do
+        expect(schema[:resources][0][:extra_attributes][:net_sales][:readable])
+          .to eq(:guarded)
+      end
+    end
+
+    context 'when sideload whitelist' do
+      before do
+        test_context.sideload_whitelist = {
+          index: { positions: 'department' }
+        }
+      end
+
+      it 'is reflected in the schema' do
+        endpoint = schema[:endpoints][:"/api/v1/schema/employees"]
+        expect(endpoint[:actions][:index][:sideload_whitelist]).to eq({
+          positions: { department: {} }
+        })
+      end
+    end
+
+    context 'when 2 resources, same path' do
+      let(:employee_search_resource) do
+        Class.new(application_resource) do
+          def self.name;'Schema::EmployeeSearchResource';end
+          self.endpoint = { path: :'/schema/employees', actions: [:index] }
+        end
+      end
+
+      before do
+        resources.unshift(employee_search_resource)
+      end
+
+      context 'and there is no conflict' do
+        before do
+          employee_resource.endpoint[:actions].delete(:index)
+        end
+
+        it 'generates correctly' do
+          endpoint = schema[:endpoints][:"/api/v1/schema/employees"]
+          expect(endpoint[:actions][:index][:resource])
+            .to eq('Schema::EmployeeSearchResource')
+        end
+      end
+
+      context 'and there is a conflict' do
+        it 'raises error' do
+          expect {
+            schema
+          }.to raise_error(JsonapiCompliable::Errors::ResourceEndpointConflict)
+        end
+      end
+    end
+
+    context 'when 1 resource, multiple endpoints' do
+      before do
+        employee_resource.add_endpoint :'/special_employees', [:index]
+      end
+
+      it 'generates correctly' do
+        expect(schema[:endpoints]).to eq({
+          :'/api/v1/schema/employees' => {
+            actions: {
+              index: { resource: 'Schema::EmployeeResource' },
+              show: { resource: 'Schema::EmployeeResource' },
+              create: { resource: 'Schema::EmployeeResource' },
+              update: { resource: 'Schema::EmployeeResource' },
+              destroy: { resource: 'Schema::EmployeeResource' }
+            }
+          },
+          :'/api/v1/special_employees' => {
+            actions: {
+              index: { resource: 'Schema::EmployeeResource' }
+            }
+          }
+        })
+      end
+    end
+
+    context 'when context not found for endpoint' do
+      let(:test_context) { nil }
+
+      it 'does not add the endpoint to the schema' do
+        expect(schema[:endpoints]).to eq({})
+      end
+    end
+
+    context 'when context not found for a specific endpoint action' do
+      around do |e|
+        JsonapiCompliable.config.context_for_endpoint = ->(path, action) {
+          test_context if [:show, :create].include?(action)
+        }
+        begin
+          e.run
+        ensure
+          JsonapiCompliable.config.context_for_endpoint = nil
+        end
+      end
+
+      it 'does not add the action to the schema' do
+        expect(schema[:endpoints][:'/api/v1/schema/employees'][:actions].keys)
+          .to eq([:show, :create])
+      end
+    end
+
+    context 'when polymorphic resources' do
+      let(:resources) { [PORO::CreditCardResource] }
+
+      it 'generates a polymorphic schema for the resource' do
+        expect(schema[:resources][0][:polymorphic]).to eq(true)
+        expect(schema[:resources][0][:children])
+          .to eq(['PORO::VisaResource', 'PORO::MastercardResource'])
+      end
+    end
+
+    context 'when polymorphic relationship' do
+      let(:house_resource) do
+        Class.new(application_resource) do
+          def self.name;'Schema::HouseResource';end
+        end
+      end
+
+      let(:condo_resource) do
+        Class.new(application_resource) do
+          def self.name;'Schema::CondoResource';end
+        end
+      end
+
+      before do
+        _house = house_resource
+        _condo = condo_resource
+        employee_resource.class_eval do
+          polymorphic_belongs_to :dwelling do
+            group_by(:dwelling_type) do
+              on(:House).belongs_to(:adf, resource: _house)
+              on(:Condo).belongs_to(:condo, resource: _condo)
+            end
+          end
+        end
+      end
+
+      it 'associates the relationship with multiple resources' do
+        expect(schema[:resources][0][:relationships][:dwelling]).to eq({
+          type: :polymorphic_belongs_to,
+          resources: ['Schema::HouseResource', 'Schema::CondoResource']
+        })
+      end
+    end
+
+    context 'when Rails is defined' do
+      let(:rails) do
+        double(application: double(eager_load!: true))
+      end
+
+      before do
+        stub_const('Rails', rails)
+      end
+
+      it 'eager loads classes' do
+        expect(rails.application).to receive(:eager_load!)
+        schema
+      end
+    end
+
+    context 'when given a hash attribute w/schema' do
+      xit 'is noted as record type' do
+
+      end
+    end
+
+    context 'when enum' do
+      xit 'lists variants' do
+      end
+    end
+  end
+end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -448,7 +448,13 @@ RSpec.describe 'serialization' do
             .constructor { |input|
               'custom!'
             }
-          JsonapiCompliable::Types[:custom] = { read: type }
+          JsonapiCompliable::Types[:custom] = {
+            read: type,
+            write: type,
+            params: type,
+            kind: 'scalar',
+            description: 'test'
+          }
           resource.attribute :age, :custom
         end
 

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe JsonapiCompliable::Types do
   describe '.[]=' do
     context 'when key is string' do
       before do
-        described_class['string'] = 'foo'
+        described_class['string'] = {
+          params: 'foo',
+          read: 'foo',
+          test: 'foo',
+          write: 'foo',
+          kind: 'foo',
+          description: 'foo'
+        }
       end
 
       it 'works' do
@@ -16,27 +23,36 @@ RSpec.describe JsonapiCompliable::Types do
       end
     end
 
-    context 'when value is a hash' do
-      before do
-        described_class[:string] = { foo: 'bar' }
-      end
-
-      it 'works' do
-        expect(described_class[:string]).to eq(foo: 'bar')
+    context 'when value is not a hash' do
+      it 'raises error' do
+        expect {
+          described_class[:string] = 'foo'
+        }.to raise_error(JsonapiCompliable::Errors::InvalidType)
       end
     end
 
-    context 'when value is a type' do
-      before do
-        described_class[:string] = 'foo'
+    context 'when value is a hash' do
+      context 'with all required keys' do
+        it 'works' do
+          type = {
+            params: 'foo',
+            read: 'foo',
+            test: 'foo',
+            write: 'foo',
+            kind: 'foo',
+            description: 'foo'
+          }
+          described_class[:string] = type
+          expect(described_class[:string]).to eq(type)
+        end
       end
 
-      it 'assigns the type to all operations' do
-        expect(described_class[:string]).to eq({
-          read: 'foo',
-          params: 'foo',
-          test: 'foo'
-        })
+      context 'missing required keys' do
+        it 'raises error' do
+          expect {
+            described_class[:string] = { foo: 'bar' }
+          }.to raise_error(JsonapiCompliable::Errors::InvalidType)
+        end
       end
     end
   end
@@ -64,9 +80,6 @@ RSpec.describe JsonapiCompliable::Types do
       expect(types).to include(:array_of_dates)
       expect(types).to include(:array_of_floats)
       expect(types).to include(:array_of_big_decimals)
-      expect(types).to include(:array_of_booleans)
-      expect(types).to include(:array_of_hashes)
-      expect(types).to include(:array_of_arrays)
     end
   end
 


### PR DESCRIPTION
`JsonapiCompliable::Schema.generate([Array, Of, Resource, Classes])`
will generate a jsonapi-specific schema. A backwards-compatibility check
will be added in a subsequent commit.

If using Rails, no need to pass an array of classes. We will eager load
everything and grab all relevant descendants of Resource.

Notes:

* Filters can now limit operators with `only:` and `except:`
* Resources are now associated with endpoints. A subsequent commit will
ensure resources cannot be called from an endpoint if not whitelisted.
This will tie into automatic link generation.
* We now require all relevant keys when registering a custom type.
* This is a first-pass and will be altered as we roll out 1.0