### PR TITLE
Ensure resource+endpoint whitelists are enforced

### DIFF
--- a/lib/jsonapi_compliable/errors.rb
+++ b/lib/jsonapi_compliable/errors.rb
@@ -75,6 +75,30 @@ The adapter #{@adapter.class} does not implement method '#{@method}', which was 
       end
     end
 
+    class InvalidEndpoint < Base
+      def initialize(resource_class, path, action)
+        @resource_class = resource_class
+        @path = path
+        @action = action
+      end
+
+      def message
+        <<-MSG
+#{@resource_class.name} cannot be called directly from endpoint #{@path}##{@action}!
+
+Either set a primary endpoint for this resource:
+
+endpoint '/my/url', [:index, :show, :create]
+
+Or whitelist a secondary endpoint:
+
+secondary_endoint '/my_url', [:index, :update]
+
+The current endpoints allowed for this resource are: #{@resource_class.endpoints.inspect}
+        MSG
+      end
+    end
+
     class InvalidType < Base
       def initialize(key, value)
         @key = key

--- a/lib/jsonapi_compliable/resource.rb
+++ b/lib/jsonapi_compliable/resource.rb
@@ -22,12 +22,20 @@ module JsonapiCompliable
       end
     end
 
-    def context
+    def self.context
       JsonapiCompliable.context[:object]
     end
 
-    def context_namespace
+    def context
+      self.class.context
+    end
+
+    def self.context_namespace
       JsonapiCompliable.context[:namespace]
+    end
+
+    def context_namespace
+      self.class.context_namespace
     end
 
     def build_scope(base, query, opts = {})

--- a/lib/jsonapi_compliable/resource/interface.rb
+++ b/lib/jsonapi_compliable/resource/interface.rb
@@ -5,15 +5,18 @@ module JsonapiCompliable
 
       class_methods do
         def all(params = {}, base_scope = nil)
+          validate!
           _all(params, {}, base_scope)
         end
 
+        # @api private
         def _all(params, opts, base_scope)
           runner = Runner.new(self, params)
           runner.proxy(base_scope, opts)
         end
 
         def find(params, base_scope = nil)
+          validate!
           id = params[:data].try(:[], :id) || params.delete(:id)
           params[:filter] ||= {}
           params[:filter].merge!(id: id)
@@ -23,8 +26,20 @@ module JsonapiCompliable
         end
 
         def build(params, base_scope = nil)
+          validate!
           runner = Runner.new(self, params)
           runner.proxy(base_scope, single: true, raise_on_missing: true)
+        end
+
+        private
+
+        def validate!
+          if context && context.respond_to?(:request)
+            path = context.request.env['PATH_INFO']
+            unless allow_request?(path, context_namespace)
+              raise Errors::InvalidEndpoint.new(self, path, context_namespace)
+            end
+          end
         end
       end
     end

--- a/spec/integration/rails/activerecord_poro_spec.rb
+++ b/spec/integration/rails/activerecord_poro_spec.rb
@@ -24,6 +24,15 @@ if ENV['APPRAISAL_INITIALIZED']
     let!(:book) { Legacy::Book.create!(title: 'Foo', author: author) }
     let!(:state) { Legacy::State.create!(name: 'Maine') }
 
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/legacy/author_searches' }
+
     it 'works' do
       get :index, params: { include: 'special_books' }
       expect(d[0].sideload(:special_books).map(&:id)).to eq([book.id])

--- a/spec/integration/rails/before_commit_spec.rb
+++ b/spec/integration/rails/before_commit_spec.rb
@@ -17,6 +17,15 @@ if ENV["APPRAISAL_INITIALIZED"]
       $raise_on_before_commit = { employee: true }
     end
 
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/integration_hooks/employees' }
+
     module IntegrationHooks
       class ApplicationResource < JsonapiCompliable::Resource
         self.adapter = JsonapiCompliable::Adapters::ActiveRecord::Base.new

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -52,6 +52,15 @@ if ENV['APPRAISAL_INITIALIZED']
     let!(:house)   { Legacy::House.new(name: 'Cozy', state: state) }
     let!(:condo)   { Legacy::Condo.new(name: 'Modern') }
 
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/legacy/authors' }
+
     it 'allows basic sorting' do
       get :index, params: { sort: '-id' }
       expect(d.map(&:id)).to eq([author2.id, author1.id])
@@ -592,6 +601,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       let(:id) { author1.id.to_s }
+      let(:path) { "/legacy/authors/#{id}" }
 
       it 'works' do
         make_request

--- a/spec/integration/rails/hooks_spec.rb
+++ b/spec/integration/rails/hooks_spec.rb
@@ -99,6 +99,16 @@ if ENV["APPRAISAL_INITIALIZED"]
       }
     end
 
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/integration_hooks/authors' }
+
+
     def json
       JSON.parse(response.body)
     end

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -50,6 +50,15 @@ if ENV["APPRAISAL_INITIALIZED"]
     end
 
     before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/employees' }
+
+    before do
       @request.headers['Accept'] = Mime[:json]
       @request.headers['Content-Type'] = Mime[:json].to_s
 
@@ -113,6 +122,8 @@ if ENV["APPRAISAL_INITIALIZED"]
         }
       end
 
+      let(:path) { "/employees/#{employee.id}" }
+
       it 'updates the data correctly' do
         expect {
           do_put(employee.id)
@@ -139,6 +150,8 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     describe 'basic destroy' do
       let!(:employee) { Employee.create!(first_name: 'Joe') }
+
+      let(:path) { "/employees/#{employee.id}" }
 
       before do
         allow_any_instance_of(Employee)
@@ -227,6 +240,8 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
 
         context 'on update' do
+          let(:path) { "/employees/#{employee.id}" }
+
           let(:payload) do
             {
               data: {
@@ -262,6 +277,8 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
 
         context 'on destroy' do
+          let(:path) { "/employees/#{employee.id}" }
+
           let(:payload) do
             {
               data: {
@@ -307,6 +324,8 @@ if ENV["APPRAISAL_INITIALIZED"]
               }
             }
           end
+
+          let(:path) { "/employees/#{employee.id}" }
 
           it 'can disassociate' do
             do_put(employee.id)
@@ -447,6 +466,8 @@ if ENV["APPRAISAL_INITIALIZED"]
       let!(:position2)  { Position.create!(title: 'original', department: department) }
       let!(:department) { Department.create!(name: 'original') }
 
+      let(:path) { "/employees/#{employee.id}" }
+
       let(:payload) do
         {
           data: {
@@ -537,6 +558,8 @@ if ENV["APPRAISAL_INITIALIZED"]
       context 'when disassociating' do
         let(:method) { 'disassociate' }
 
+        let(:path) { "/employees/#{employee.id}" }
+
         it 'belongs_to: updates the foreign key on child' do
           expect {
             do_put(employee.id)
@@ -563,6 +586,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
       context 'when destroying' do
         let(:method) { 'destroy' }
+        let(:path) { "/employees/#{employee.id}" }
 
         it 'deletes the objects' do
           do_put(employee.id)
@@ -651,6 +675,8 @@ if ENV["APPRAISAL_INITIALIZED"]
         employee.teams << disassociate_team
         employee.teams << destroy_team
       end
+
+      let(:path) { "/employees/#{employee.id}" }
 
       let(:payload) do
         {

--- a/spec/integration/rails/sideload_whitelist_spec.rb
+++ b/spec/integration/rails/sideload_whitelist_spec.rb
@@ -18,6 +18,15 @@ if ENV["APPRAISAL_INITIALIZED"]
     let!(:book) { Legacy::Book.create!(title: 'The Shining', author: author, genre: genre) }
     let!(:genre) { Legacy::Genre.create!(name: 'Horror') }
 
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with('PATH_INFO') { path }
+    end
+
+    let(:path) { '/legacy/authors' }
+
     context 'when no sideload whitelist' do
       it 'allows loading all relationships' do
         get :index, params: { include: 'books.genre' }

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe JsonapiCompliable::Schema do
       let(:employee_search_resource) do
         Class.new(application_resource) do
           def self.name;'Schema::EmployeeSearchResource';end
-          self.endpoint = { path: :'/schema/employees', actions: [:index] }
+          primary_endpoint '/schema/employees', [:index]
         end
       end
 
@@ -414,7 +414,7 @@ RSpec.describe JsonapiCompliable::Schema do
 
     context 'when 1 resource, multiple endpoints' do
       before do
-        employee_resource.add_endpoint :'/special_employees', [:index]
+        employee_resource.secondary_endpoint '/special_employees', [:index]
       end
 
       it 'generates correctly' do


### PR DESCRIPTION
Each resource (optionally) has a primary endpoint and (optionally)
secondary endpoints. The primary endpoint is used for link generation,
the secondary endpoints serve as a whitelist. These endpoints are used
to generate the schema.

We wouldn't want to define an endpoint, generate a schema, but also
accidentally call the wrong resource in the actual runtime code. This
commit ensures only a resource associated with a given endpoint can be
called.

This behavior can be overriden:

```ruby
def self.allow_request?(path, action)
  # ... code ...
end
```

To whitelist endpoints:

```ruby
primary_endpoint '/foo', [:index, :show]
secondary_endpoint '/bar', [:create]
```

The primary endpoint is derived from the class name by default. To do
nothing but limit the actions:

```ruby
self.endpoint[:actions].delete(:index)
```