### PR TITLE
Allow stats to optionally gain access to resource

### DIFF
--- a/lib/jsonapi_compliable/stats/payload.rb
+++ b/lib/jsonapi_compliable/stats/payload.rb
@@ -33,7 +33,8 @@ module JsonapiCompliable
             stats[name] = {}
 
             each_calculation(name, calculation) do |calc, function|
-              stats[name][calc] = function.call(@scope, name)
+              args = function.arity == 3 ? [@scope, name, @resource] : [@scope, name]
+              stats[name][calc] = function.call(*args)
             end
           end
         end

--- a/spec/stats/payload_spec.rb
+++ b/spec/stats/payload_spec.rb
@@ -9,14 +9,19 @@ RSpec.describe JsonapiCompliable::Stats::Payload do
   describe '#generate' do
     subject { instance.generate }
 
-    def stub_stat(attr, calc, result)
-      allow(dsl).to receive(:stat).with(attr, calc) { ->(_,_) { result } }
+    def stub_stat(attr, calc, result, with_resource=false)
+      if with_resource
+        allow(dsl).to receive(:stat).with(attr, calc) { ->(_,_,_) { result } }
+      else
+        allow(dsl).to receive(:stat).with(attr, calc) { ->(_,_) { result } }
+      end
     end
 
     before do
       stub_stat(:attr1, :count, 2)
       stub_stat(:attr1, :average, 1)
       stub_stat(:attr2, :maximum, 3)
+      stub_stat(:attr3, :maximum, 3, true)
     end
 
     it 'generates the correct payload for each requested stat' do


### PR DESCRIPTION
Some stats may need the data to react to conditions passed to the
resource so it is useful to allow that without breaking the api for
existing measures.