### PR TITLE
Improve error handling in JSONAPI deserializer

### DIFF
--- a/lib/jsonapi_compliable/base.rb
+++ b/lib/jsonapi_compliable/base.rb
@@ -345,7 +345,7 @@ module JsonapiCompliable
     end
 
     def force_includes?
-      not deserialized_params.data.nil?
+      not (deserialized_params.data.nil? || deserialized_params.data.empty?)
     end
 
     def perform_render_jsonapi(opts)

--- a/lib/jsonapi_compliable/deserializer.rb
+++ b/lib/jsonapi_compliable/deserializer.rb
@@ -48,14 +48,23 @@ class JsonapiCompliable::Deserializer
   # @param payload [Hash] The incoming payload with symbolized keys
   # @param env [Hash] the Rack env (e.g. +request.env+).
   def initialize(payload, env)
-    @payload = payload
+    @payload = payload || {}
     @payload = @payload[:_jsonapi] if @payload.has_key?(:_jsonapi)
     @env = env
+    validate_content_type
+  end
+
+  # checks Content-Type header and prints a warning if it doesn't seem correct
+  def validate_content_type
+    content_type = @env['CONTENT_TYPE'] || ""
+    if !(content_type.include?("application/json") || content_type.include?("application/vnd.api+json"))
+      print("WARNING - JSONAPI Compliable :: Content-Type header appears to be set to an invalid value: #{content_type}\n")
+    end
   end
 
   # @return [Hash] the raw :data value of the payload
   def data
-    @payload[:data]
+    @payload[:data] || {}
   end
 
   # @return [String] the raw :id value of the payload


### PR DESCRIPTION
1. Add conditional checks for `@payload` and `data` to not return nils
1. Print a warning when Content-Type header is set to something other than what JSONAPI expects to lead the developer in the right direction to fix the issue.